### PR TITLE
Fix for missing icp_odometry node for install targets and message generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,7 @@ install(TARGETS
    rtabmap 
    rtabmapviz 
    rgbd_odometry 
+   icp_odometry
    rgbdicp_odometry 
    stereo_odometry
    map_assembler
@@ -397,6 +398,7 @@ install(TARGETS
    rtabmap_ros 
    rtabmap 
    rgbd_odometry 
+   icp_odometry
    rgbdicp_odometry 
    stereo_odometry
    map_assembler

--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,7 @@
   <build_depend>octomap_ros</build_depend>
   <build_depend>image_geometry</build_depend>
   <build_depend>find_object_2d</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>
@@ -73,6 +74,7 @@
   <run_depend>octomap_ros</run_depend>
   <run_depend>image_geometry</run_depend>
   <run_depend>find_object_2d</run_depend>
+  <run_depend>message_runtime</run_depend>
 
   <build_depend>libpcl-all-dev</build_depend>
 


### PR DESCRIPTION
I'm running ROS kinetic on ubuntu 16.04.
1. I'm currently running a setup on a mobile base without a wheel encoder. This probably not the most common use-case, but the deployed package (0.17.0-1, installed through `apt`) does not contain the `icp_odometry` node that is required to run the demo at `launch/demo/demo_hector_mapping` with `hector:=false`. I was trying to go by the setup described in section 2.3 of [this link](http://wiki.ros.org/rtabmap_ros/Tutorials/SetupOnYourRobot), which lists `icp_odometry` as an option for a setup that is very similar to mine (an RGB-D sensor and a 2D laser). The fix includes the node as an install target in CMakeLists.txt.
2. Afterwards, as I was trying to source-install the package, I discovered that the package would not `catkin build` without specifying the `message_generation` and `message_runtime` dependencies in `package.xml`. The fix includes these dependencies.