### PR TITLE
Use project name as basename for interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,11 @@ find_package(rviz_default_plugins REQUIRED)
  )
 
 ## Generate messages and services
- rosidl_generate_interfaces(rtabmap_msgs
+ rosidl_generate_interfaces(${PROJECT_NAME}_msgs
    ${msg_files}
    ${srv_files}
    DEPENDENCIES geometry_msgs std_msgs sensor_msgs std_srvs visualization_msgs image_geometry
+   LIBRARY_NAME ${PROJECT_NAME}
  )
 ament_export_dependencies(rosidl_default_runtime)
 
@@ -270,9 +271,9 @@ target_link_libraries(rtabmap_ros ${RTABMap_LIBRARIES})
 target_link_libraries(rtabmap_sync rtabmap_ros ${RTABMap_LIBRARIES})
 target_link_libraries(rtabmap_plugins rtabmap_ros ${RTABMap_LIBRARIES})
 
-rosidl_target_interfaces(rtabmap_ros rtabmap_msgs "rosidl_typesupport_cpp")
-rosidl_target_interfaces(rtabmap_sync rtabmap_msgs "rosidl_typesupport_cpp")
-rosidl_target_interfaces(rtabmap_plugins rtabmap_msgs "rosidl_typesupport_cpp")
+rosidl_target_interfaces(rtabmap_ros ${PROJECT_NAME}_msgs "rosidl_typesupport_cpp")
+rosidl_target_interfaces(rtabmap_sync ${PROJECT_NAME}_msgs "rosidl_typesupport_cpp")
+rosidl_target_interfaces(rtabmap_plugins ${PROJECT_NAME}_msgs "rosidl_typesupport_cpp")
 
 rclcpp_components_register_nodes(rtabmap_plugins "rtabmap_ros::RGBDOdometry")
 rclcpp_components_register_nodes(rtabmap_plugins "rtabmap_ros::StereoOdometry")
@@ -421,34 +422,34 @@ get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
 
 foreach(typesupport_impl ${typesupport_impls})
   rosidl_target_interfaces(rtabmap_rgbd_odometry
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap_stereo_odometry
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap_icp_odometry
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap_rgbd_relay
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap_rgbd_sync
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap_stereo_sync
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap_pointcloud_to_depthimage
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap_point_cloud_xyzrgb
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmap
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
   rosidl_target_interfaces(rtabmapviz
-    rtabmap_msgs ${typesupport_impl}
+    ${PROJECT_NAME}_msgs ${typesupport_impl}
   )
 endforeach()
 
@@ -507,7 +508,7 @@ IF(rviz_default_plugins_FOUND)
 
     foreach(typesupport_impl ${typesupport_impls})
 	  rosidl_target_interfaces(rtabmap_rviz_plugins
-	    rtabmap_msgs ${typesupport_impl}
+	    ${PROJECT_NAME}_msgs ${typesupport_impl}
 	  )
     endforeach()
     

--- a/package.xml
+++ b/package.xml
@@ -53,6 +53,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>nav2_common</exec_depend>
   <exec_depend>stereo_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
@@ -70,7 +71,6 @@
   <exec_depend>octomap</exec_depend>
   <exec_depend>image_geometry</exec_depend>
   <exec_depend>find_object_2d</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>pluginlib</exec_depend>
 
   <build_depend>libpcl-all-dev</build_depend>


### PR DESCRIPTION
As noted by Dirk Thomas in ros2/rosidl#441, libraries for generated
interfaces must use ${PROJECT_NAME} as their basename.  This PR
modifies rtabmap_ros so that it does so.

It also tweaks a couple of rosdep keys because nav2_common was used in
some launch files but not included, and message_runtime does not exist
in ROS 2.

Fixes #397