### PR TITLE
updating files to build ros package with rtab-map lib v0.20.3

### DIFF
--- a/src/CoreWrapper.cpp
+++ b/src/CoreWrapper.cpp
@@ -1883,10 +1883,10 @@ void CoreWrapper::process(
 				if(maxMappingNodes_ > 0 && filteredPoses.size()>1)
 				{
 					std::map<int, Transform> nearestPoses;
-					std::vector<int> nodes = graph::findNearestNodes(filteredPoses, mapToOdom_*odom, maxMappingNodes_);
-					for(std::vector<int>::iterator iter=nodes.begin(); iter!=nodes.end(); ++iter)
+					std::map<int, float> nodes = graph::findNearestNodes(filteredPoses, mapToOdom_*odom, maxMappingNodes_);
+					for(std::map<int, float>::iterator iter=nodes.begin(); iter!=nodes.end(); ++iter)
 					{
-						std::map<int, Transform>::iterator pter = filteredPoses.find(*iter);
+						std::map<int, Transform>::iterator pter = filteredPoses.find(iter->first);
 						if(pter != filteredPoses.end())
 						{
 							nearestPoses.insert(*pter);
@@ -2770,10 +2770,10 @@ void CoreWrapper::publishMapCallback(
 			if(maxMappingNodes_ > 0 && filteredPoses.size()>1)
 			{
 				std::map<int, Transform> nearestPoses;
-				std::vector<int> nodes = graph::findNearestNodes(filteredPoses, filteredPoses.rbegin()->second, maxMappingNodes_);
-				for(std::vector<int>::iterator iter=nodes.begin(); iter!=nodes.end(); ++iter)
+				std::map<int, float> nodes = graph::findNearestNodes(filteredPoses, filteredPoses.rbegin()->second, maxMappingNodes_);
+				for(std::map<int, float>::iterator iter=nodes.begin(); iter!=nodes.end(); ++iter)
 				{
-					std::map<int, Transform>::iterator pter = filteredPoses.find(*iter);
+					std::map<int, Transform>::iterator pter = filteredPoses.find(iter->first);
 					if(pter != filteredPoses.end())
 					{
 						nearestPoses.insert(*pter);

--- a/src/OdometryROS.cpp
+++ b/src/OdometryROS.cpp
@@ -654,7 +654,9 @@ void OdometryROS::processData(const SensorData & data, const rclcpp::Time & stam
 			for(std::map<int, cv::Point3f>::const_iterator iter=info.localMap.begin(); iter!=info.localMap.end(); ++iter)
 			{
 				bool inlier = info.words.find(iter->first) != info.words.end();
-				pcl::PointXYZRGB pt(inlier?0:255, 255, 0);
+				pcl::PointXYZRGB pt;
+				pt.r = inlier?0:255;
+				pt.g = 255;
 				pt.x = iter->second.x;
 				pt.y = iter->second.y;
 				pt.z = iter->second.z;


### PR DESCRIPTION
Hi. While following the README in the "ros2" branch I faced two issues. The first one regards the PCL version. For PCL version equals or greater than 10.1, the change made in 'src/OdometryROS.cpp' is necessary, which is the same modification made to fix #450 but in the "melodic" branch. Second, the latest version of RTAB-LIB (v0.20.3) has changed the variable type of the method 'graph::findNearestNodes', which justifies the modification made in 'src/CoreWrapper.cpp' (please refer to #470).
After these changes, I could successfully build RTAB-LIB ROS2 (Eloquent) package. I appreciated if you could check it! 

Thanks!