### PR TITLE
Add support for stereo + 2dscan to build grid map.

### DIFF
--- a/include/rtabmap_ros/CommonDataSubscriber.h
+++ b/include/rtabmap_ros/CommonDataSubscriber.h
@@ -150,6 +150,10 @@ private:
 			ros::NodeHandle & nh,
 			ros::NodeHandle & pnh,
 			bool subscribeOdom,
+			bool subscribeUserData,
+			bool subscribeScan2d,
+			bool subscribeScan3d,
+			bool subscribeScanDesc,
 			bool subscribeOdomInfo,
 			int queueSize,
 			bool approxSync);
@@ -319,10 +323,13 @@ private:
 	// Stereo
 	DATA_SYNCS4(stereo, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo);
 	DATA_SYNCS5(stereoInfo, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo, rtabmap_ros::OdomInfo);
+	DATA_SYNCS5(stereoScan, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo, sensor_msgs::LaserScan);
 
 	// Stereo + Odom
 	DATA_SYNCS5(stereoOdom, nav_msgs::Odometry, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo);
 	DATA_SYNCS6(stereoOdomInfo, nav_msgs::Odometry, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo, rtabmap_ros::OdomInfo);
+	DATA_SYNCS7(stereoScanOdomInfo, nav_msgs::Odometry, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo, sensor_msgs::LaserScan, rtabmap_ros::OdomInfo);
+	DATA_SYNCS6(stereoScanOdom, nav_msgs::Odometry, sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo, sensor_msgs::CameraInfo, sensor_msgs::LaserScan);
 
 	// RGB-only
 	DATA_SYNCS2(rgb, sensor_msgs::Image, sensor_msgs::CameraInfo);

--- a/src/CommonDataSubscriber.cpp
+++ b/src/CommonDataSubscriber.cpp
@@ -89,10 +89,13 @@ CommonDataSubscriber::CommonDataSubscriber(bool gui) :
 		// Stereo
 		SYNC_INIT(stereo),
 		SYNC_INIT(stereoInfo),
+		SYNC_INIT(stereoScan),
 
 		// Stereo + Odom
 		SYNC_INIT(stereoOdom),
 		SYNC_INIT(stereoOdomInfo),
+		SYNC_INIT(stereoScanOdom),
+		SYNC_INIT(stereoScanOdomInfo),
 		
 		// RGB-only
 		SYNC_INIT(rgb),
@@ -473,6 +476,7 @@ void CommonDataSubscriber::setupCallbacks(
 	ROS_INFO("%s: subscribe_scan = %s", name.c_str(), subscribeScan2d?"true":"false");
 	ROS_INFO("%s: subscribe_scan_cloud = %s", name.c_str(), subscribeScan3d?"true":"false");
 	ROS_INFO("%s: subscribe_scan_descriptor = %s", name.c_str(), subscribeScanDesc?"true":"false");
+	ROS_INFO("%s: subscribe_odom = %s", name.c_str(), subscribeOdom?"true":"false");
 	ROS_INFO("%s: queue_size    = %d", name.c_str(), queueSize_);
 	ROS_INFO("%s: approx_sync   = %s", name.c_str(), approxSync_?"true":"false");
 
@@ -497,6 +501,10 @@ void CommonDataSubscriber::setupCallbacks(
 				nh,
 				pnh,
 				subscribedToOdom_,
+				subscribeUserData,
+				subscribeScan2d,
+				subscribeScan3d,
+				subscribeScanDesc,
 				subscribeOdomInfo,
 				queueSize_,
 				approxSync_);
@@ -666,10 +674,13 @@ CommonDataSubscriber::~CommonDataSubscriber()
 	// Stereo
 	SYNC_DEL(stereo);
 	SYNC_DEL(stereoInfo);
+	SYNC_DEL(stereoScan);
 
 	// Stereo + Odom
 	SYNC_DEL(stereoOdom);
 	SYNC_DEL(stereoOdomInfo);
+	SYNC_DEL(stereoScanOdom);
+	SYNC_DEL(stereoScanOdomInfo);
 	
 	// RGB-only
 	SYNC_DEL(rgb);

--- a/src/MapsManager.cpp
+++ b/src/MapsManager.cpp
@@ -598,6 +598,17 @@ std::map<int, rtabmap::Transform> MapsManager::updateMapCaches(
 								generateGrid?0:&obstacles,
 								generateGrid?0:&emptyCells);
 
+						if ((updateGrid == true) && (updateOctomap == false) && (obstacles.channels() == 3)) {
+							cv::Mat obstacle2D(1, obstacles.cols, CV_32FC2);
+							for (int i = 0; i < obstacles.cols; ++i) {
+								const float * vi = obstacles.ptr<float>(0, i);
+								float * vo = obstacle2D.ptr<float>(0, i);
+								vo[0] = vi[0];
+								vo[1] = vi[1];
+							}
+							obstacles = obstacle2D;
+						}
+
 						if(generateGrid)
 						{
 							Signature tmp(data);


### PR DESCRIPTION
Add support for stereo + odom + 2d scan method to build a 2d grid map. I have tested with my own rosbag with topics as:
               

/camera/infra1/camera_info                  1514 msgs    : sensor_msgs/CameraInfo     
                /camera/infra1/image_rect_raw/compressed    1514 msgs    : sensor_msgs/CompressedImage
                /camera/infra2/camera_info                  1514 msgs    : sensor_msgs/CameraInfo     
                /camera/infra2/image_rect_raw/compressed    1514 msgs    : sensor_msgs/CompressedImage         
                /odom                                      10092 msgs    : nav_msgs/Odometry          
                /scan                                       1400 msgs    : sensor_msgs/LaserScan       
                /tf_static                                     2 msgs    : tf2_msgs/TFMessage          (2 connections)

![Screenshot from 2020-10-12 17-24-34](https://user-images.githubusercontent.com/42230212/95729888-1c175280-0cb0-11eb-8018-5468e9ee492d.png)
![Screenshot from 2020-10-12 17-25-15](https://user-images.githubusercontent.com/42230212/95729894-1de11600-0cb0-11eb-8e0d-b9d56870090d.png)
![Screenshot from 2020-10-12 17-25-29](https://user-images.githubusercontent.com/42230212/95729895-1e79ac80-0cb0-11eb-838a-68f23888aa3b.png)

