### PR TITLE
Add missing dependency on rviz_common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(tf2_ros REQUIRED)
 #find_package(eigen_conversions REQUIRED)
 find_package(laser_geometry REQUIRED)
@@ -177,6 +178,7 @@ SET(Libraries
    geometry_msgs
    image_transport
    tf2
+   tf2_eigen
    tf2_ros
    laser_geometry
    message_filters

--- a/package.xml
+++ b/package.xml
@@ -45,6 +45,8 @@
   <build_depend>image_geometry</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>rviz_common</build_depend>
+  <build_depend>rviz_rendering</build_depend>
+  <build_depend>rviz_default_plugins</build_depend>
 
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>rclcpp</exec_depend>
@@ -74,6 +76,8 @@
   <exec_depend>find_object_2d</exec_depend>
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>rviz_common</exec_depend>
+  <exec_depend>rviz_rendering</exec_depend>
+  <exec_depend>rviz_default_plugins</exec_depend>
 
   <build_depend>libpcl-all-dev</build_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -65,6 +65,7 @@
   <exec_depend>compressed_depth_image_transport</exec_depend>
   <exec_depend>compressed_image_transport</exec_depend>
   <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_eigen</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>laser_geometry</exec_depend>
   <exec_depend>pcl_conversions</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,7 @@
   <build_depend>octomap</build_depend>
   <build_depend>image_geometry</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>rviz_common</build_depend>
 
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>rclcpp</exec_depend>
@@ -72,6 +73,7 @@
   <exec_depend>image_geometry</exec_depend>
   <exec_depend>find_object_2d</exec_depend>
   <exec_depend>pluginlib</exec_depend>
+  <exec_depend>rviz_common</exec_depend>
 
   <build_depend>libpcl-all-dev</build_depend>
 


### PR DESCRIPTION
As used in the CMakeLists.txt: https://github.com/introlab/rtabmap_ros/blob/ros2/CMakeLists.txt#L81