### PR TITLE
fix possible stackunderflow in CoreWrapper constructed function

### DIFF
--- a/include/rtabmap_ros/CoreWrapper.h
+++ b/include/rtabmap_ros/CoreWrapper.h
@@ -233,6 +233,10 @@ private:
 	std::string groundTruthBaseFrameId_;
 	std::string configPath_;
 	std::string databasePath_;
+
+	double tfDelay;
+	double tfTolerance;
+
 	double odomDefaultAngVariance_;
 	double odomDefaultLinVariance_;
 	double landmarkDefaultAngVariance_;

--- a/src/CoreWrapper.cpp
+++ b/src/CoreWrapper.cpp
@@ -138,8 +138,8 @@ CoreWrapper::CoreWrapper(const rclcpp::NodeOptions & options) :
 	tfBroadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
 
 	bool publishTf = true;
-	double tfDelay = 0.05; // 20 Hz
-	double tfTolerance = 0.1; // 100 ms
+	tfDelay = 0.05; // 20 Hz
+	tfTolerance = 0.1; // 100 ms
 
 	configPath_ = this->declare_parameter("config_path", configPath_);
 	databasePath_ = this->declare_parameter("database_path", databasePath_);


### PR DESCRIPTION
```cpp
CoreWrapper::CoreWrapper(const rclcpp::NodeOptions & options) : ... {
    ....
    double tfDelay = 0.05; // 20 Hz
    double tfTolerance = 0.1; // 100 ms
    ...
        transformThread_ = new std::thread([&](){
            // the thread's lifetime is longer than the constructed function.
            // using a local variable of the stack in the new thread
            if(tfDelay == 0)
		return;
            ....
            // using a local variable of the stack in the new thread
            rclcpp::Time tfExpiration = now() + rclcpp::Duration(tfTolerance*10e9);
        }

}
```