### PR TITLE
Replace boost::bind by std::bind.

### DIFF
--- a/src/CameraNode.cpp
+++ b/src/CameraNode.cpp
@@ -278,7 +278,7 @@ int main(int argc, char** argv)
 
 	dynamic_reconfigure::Server<rtabmap_ros::CameraConfig> server;
 	dynamic_reconfigure::Server<rtabmap_ros::CameraConfig>::CallbackType f;
-	f = boost::bind(&callback, _1, _2);
+	f = std::bind(&callback, std::placeholders::_1, std::placeholders::_2);
 	server.setCallback(f);
 
 	ros::spin();

--- a/src/MapOptimizerNode.cpp
+++ b/src/MapOptimizerNode.cpp
@@ -103,7 +103,7 @@ public:
 			ROS_INFO("map_optimizer: map_frame_id = %s", mapFrameId_.c_str());
 			ROS_INFO("map_optimizer: odom_frame_id = %s", odomFrameId_.c_str());
 			ROS_INFO("map_optimizer: tf_delay = %f", tfDelay);
-			transformThread_ = new boost::thread(boost::bind(&MapOptimizer::publishLoop, this, tfDelay));
+			transformThread_ = new boost::thread(std::bind(&MapOptimizer::publishLoop, this, tfDelay));
 		}
 	}
 

--- a/src/costmap_2d/static_layer.cpp
+++ b/src/costmap_2d/static_layer.cpp
@@ -109,8 +109,8 @@ void StaticLayer::onInitialize()
   }
 
   dsrv_ = new dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>(nh);
-  dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb = boost::bind(
-      &StaticLayer::reconfigureCB, this, _1, _2);
+  dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb = std::bind(
+      &StaticLayer::reconfigureCB, this, std::placeholders::_1, std::placeholders::_2);
   dsrv_->setCallback(cb);
 }
 

--- a/src/costmap_2d/voxel_layer.cpp
+++ b/src/costmap_2d/voxel_layer.cpp
@@ -77,8 +77,8 @@ void VoxelLayer::onInitialize()
 void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
 {
   voxel_dsrv_ = new dynamic_reconfigure::Server<VoxelPluginConfig>(nh);
-  dynamic_reconfigure::Server<VoxelPluginConfig>::CallbackType cb = boost::bind(
-      &VoxelLayer::reconfigureCB, this, _1, _2);
+  dynamic_reconfigure::Server<VoxelPluginConfig>::CallbackType cb = std::bind(
+      &VoxelLayer::reconfigureCB, this, std::placeholders::_1, std::placeholders::_2);
   voxel_dsrv_->setCallback(cb);
 }
 

--- a/src/nodelets/data_odom_sync.cpp
+++ b/src/nodelets/data_odom_sync.cpp
@@ -75,7 +75,7 @@ private:
 		private_nh.param("queue_size", queueSize, queueSize);
 
 		sync_ = new message_filters::Synchronizer<MySyncPolicy>(MySyncPolicy(queueSize), image_sub_, image_depth_sub_, info_sub_, odom_sub_);
-		sync_->registerCallback(boost::bind(&DataOdomSyncNodelet::callback, this, _1, _2, _3, _4));
+		sync_->registerCallback(std::bind(&DataOdomSyncNodelet::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 
 		image_sub_.subscribe(rgb_it, rgb_nh.resolveName("image_in"), 1, hintsRgb);
 		image_depth_sub_.subscribe(depth_it, depth_nh.resolveName("image_in"), 1, hintsDepth);

--- a/src/nodelets/data_throttle.cpp
+++ b/src/nodelets/data_throttle.cpp
@@ -105,12 +105,12 @@ private:
 		if(approxSync)
 		{
 			approxSync_ = new message_filters::Synchronizer<MyApproxSyncPolicy>(MyApproxSyncPolicy(queueSize), image_sub_, image_depth_sub_, info_sub_);
-			approxSync_->registerCallback(boost::bind(&DataThrottleNodelet::callback, this, _1, _2, _3));
+			approxSync_->registerCallback(std::bind(&DataThrottleNodelet::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 		}
 		else
 		{
 			exactSync_ = new message_filters::Synchronizer<MyExactSyncPolicy>(MyExactSyncPolicy(queueSize), image_sub_, image_depth_sub_, info_sub_);
-			exactSync_->registerCallback(boost::bind(&DataThrottleNodelet::callback, this, _1, _2, _3));
+			exactSync_->registerCallback(std::bind(&DataThrottleNodelet::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 		}
 
 		image_sub_.subscribe(rgb_it, rgb_nh.resolveName("image_in"), 1, hintsRgb);

--- a/src/nodelets/rgbdicp_odometry.cpp
+++ b/src/nodelets/rgbdicp_odometry.cpp
@@ -151,12 +151,12 @@ private:
 			if(approxSync)
 			{
 				approxCloudSync_ = new message_filters::Synchronizer<MyApproxCloudSyncPolicy>(MyApproxCloudSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, cloud_sub_);
-				approxCloudSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackCloud, this, _1, _2, _3, _4));
+				approxCloudSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackCloud, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 			}
 			else
 			{
 				exactCloudSync_ = new message_filters::Synchronizer<MyExactCloudSyncPolicy>(MyExactCloudSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, cloud_sub_);
-				exactCloudSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackCloud, this, _1, _2, _3, _4));
+				exactCloudSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackCloud, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 			}
 
 			subscribedTopicsMsg = uFormat("\n%s subscribed to (%s sync):\n   %s,\n   %s,\n   %s, \n   %s",
@@ -173,12 +173,12 @@ private:
 			if(approxSync)
 			{
 				approxScanSync_ = new message_filters::Synchronizer<MyApproxScanSyncPolicy>(MyApproxScanSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, scan_sub_);
-				approxScanSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackScan, this, _1, _2, _3, _4));
+				approxScanSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackScan, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 			}
 			else
 			{
 				exactScanSync_ = new message_filters::Synchronizer<MyExactScanSyncPolicy>(MyExactScanSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, scan_sub_);
-				exactScanSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackScan, this, _1, _2, _3, _4));
+				exactScanSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackScan, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 			}
 
 			subscribedTopicsMsg = uFormat("\n%s subscribed to (%s sync):\n   %s,\n   %s,\n   %s, \n   %s",
@@ -425,25 +425,25 @@ protected:
 		{
 			delete approxScanSync_;
 			approxScanSync_ = new message_filters::Synchronizer<MyApproxScanSyncPolicy>(MyApproxScanSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, scan_sub_);
-			approxScanSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackScan, this, _1, _2, _3, _4));
+			approxScanSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackScan, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 		}
 		if(exactScanSync_)
 		{
 			delete exactScanSync_;
 			exactScanSync_ = new message_filters::Synchronizer<MyExactScanSyncPolicy>(MyExactScanSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, scan_sub_);
-			exactScanSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackScan, this, _1, _2, _3, _4));
+			exactScanSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackScan, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 		}
 		if(approxCloudSync_)
 		{
 			delete approxCloudSync_;
 			approxCloudSync_ = new message_filters::Synchronizer<MyApproxCloudSyncPolicy>(MyApproxCloudSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, cloud_sub_);
-			approxCloudSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackCloud, this, _1, _2, _3, _4));
+			approxCloudSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackCloud, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 		}
 		if(exactCloudSync_)
 		{
 			delete exactCloudSync_;
 			exactCloudSync_ = new message_filters::Synchronizer<MyExactCloudSyncPolicy>(MyExactCloudSyncPolicy(queueSize_), image_mono_sub_, image_depth_sub_, info_sub_, cloud_sub_);
-			exactCloudSync_->registerCallback(boost::bind(&RGBDICPOdometry::callbackCloud, this, _1, _2, _3, _4));
+			exactCloudSync_->registerCallback(std::bind(&RGBDICPOdometry::callbackCloud, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 		}
 	}
 

--- a/src/nodelets/stereo_odometry.cpp
+++ b/src/nodelets/stereo_odometry.cpp
@@ -309,13 +309,13 @@ void StereoOdometry::flushCallbacks()
 	{
 		delete approxSync_;
 		approxSync_ = new message_filters::Synchronizer<MyApproxSyncPolicy>(MyApproxSyncPolicy(queueSize()), imageRectLeft_, imageRectRight_, cameraInfoLeft_, cameraInfoRight_);
-		approxSync_->registerCallback(boost::bind(&StereoOdometry::callback, this, _1, _2, _3, _4));
+		approxSync_->registerCallback(std::bind(&StereoOdometry::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 	}
 	if(exactSync_)
 	{
 		delete exactSync_;
 		exactSync_ = new message_filters::Synchronizer<MyExactSyncPolicy>(MyExactSyncPolicy(queueSize()), imageRectLeft_, imageRectRight_, cameraInfoLeft_, cameraInfoRight_);
-		exactSync_->registerCallback(boost::bind(&StereoOdometry::callback, this, _1, _2, _3, _4));
+		exactSync_->registerCallback(std::bind(&StereoOdometry::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 	}
 }
 

--- a/src/nodelets/stereo_throttle.cpp
+++ b/src/nodelets/stereo_throttle.cpp
@@ -100,12 +100,12 @@ private:
 		if(approxSync)
 		{
 			approxSync_ = new message_filters::Synchronizer<MyApproxSyncPolicy>(MyApproxSyncPolicy(queueSize), imageLeft_, imageRight_, cameraInfoLeft_, cameraInfoRight_);
-			approxSync_->registerCallback(boost::bind(&StereoThrottleNodelet::callback, this, _1, _2, _3, _4));
+			approxSync_->registerCallback(std::bind(&StereoThrottleNodelet::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 		}
 		else
 		{
 			exactSync_ = new message_filters::Synchronizer<MyExactSyncPolicy>(MyExactSyncPolicy(queueSize), imageLeft_, imageRight_, cameraInfoLeft_, cameraInfoRight_);
-			exactSync_->registerCallback(boost::bind(&StereoThrottleNodelet::callback, this, _1, _2, _3, _4));
+			exactSync_->registerCallback(std::bind(&StereoThrottleNodelet::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
 		}
 
 		imageLeft_.subscribe(left_it, left_nh.resolveName("image"), 1, hintsLeft);


### PR DESCRIPTION
Some more occurrences of `boost::bind` which can be replaced by `std::bind`.