### PR TITLE
Bugfix Corewrapper::globalBundleAdjustmentCallback

### DIFF
--- a/src/CoreWrapper.cpp
+++ b/src/CoreWrapper.cpp
@@ -3233,7 +3233,7 @@ bool CoreWrapper::globalBundleAdjustmentCallback(rtabmap_ros::GlobalBundleAdjust
 			iterations,
 			pixelVariance,
 			rematchFeatures?"true":"false");
-	bool success = rtabmap_.globalBundleAdjustment((Optimizer::Type)optimizer, iterations, pixelVariance, rematchFeatures);
+	bool success = rtabmap_.globalBundleAdjustment((Optimizer::Type)optimizer, rematchFeatures, iterations, pixelVariance);
 	if(!success)
 	{
 		NODELET_ERROR("Post-Processing: Global Bundle Adjustment failed!");


### PR DESCRIPTION
Fixed wrong order of arguments in the call to Rtabmap::globalBundleAdjustment method.