### PR TITLE
List dependencies only once

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rtabmap_ros</name>
   <version>0.20.16</version>
   <description>RTAB-Map's ros-pkg. RTAB-Map is a RGB-D SLAM approach with real-time constraints.</description>
@@ -11,79 +11,45 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>genmsg</buildtool_depend>
-  
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>stereo_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>rosgraph_msgs</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf_conversions</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>eigen_conversions</build_depend>
-  <build_depend>laser_geometry</build_depend>
-  <build_depend>pcl_conversions</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>nodelet</build_depend>
-  <build_depend>dynamic_reconfigure</build_depend>
-  <build_depend>rviz</build_depend>
-  <build_depend>message_filters</build_depend>
-  <build_depend>class_loader</build_depend>
-  <build_depend>rtabmap</build_depend>
-  <build_depend>move_base_msgs</build_depend>
-  <build_depend>costmap_2d</build_depend>
-  <build_depend>octomap_msgs</build_depend>
-  <build_depend>image_geometry</build_depend>
-  <build_depend>find_object_2d</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>apriltag_ros</build_depend>
-
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>std_srvs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>stereo_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
-  <run_depend>rosgraph_msgs</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>theora_image_transport</run_depend>
-  <run_depend>compressed_depth_image_transport</run_depend>
-  <run_depend>compressed_image_transport</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>tf_conversions</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>eigen_conversions</run_depend>
-  <run_depend>laser_geometry</run_depend>
-  <run_depend>pcl_conversions</run_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>nodelet</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>message_filters</run_depend>
-  <run_depend>class_loader</run_depend>
-  <run_depend>rtabmap</run_depend>
-  <run_depend>move_base_msgs</run_depend>
-  <run_depend>costmap_2d</run_depend>
-  <run_depend>octomap_msgs</run_depend>
-  <run_depend>image_geometry</run_depend>
-  <run_depend>find_object_2d</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>apriltag_ros</run_depend>
 
   <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>message_generation</build_depend>
+  <depend>apriltag_ros</depend>
+  <depend>class_loader</depend>
+  <depend>costmap_2d</depend>
+  <depend>cv_bridge</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>eigen_conversions</depend>
+  <depend>find_object_2d</depend>
+  <depend>geometry_msgs</depend>
+  <depend>image_geometry</depend>
+  <depend>image_transport</depend>
+  <depend>laser_geometry</depend>
+  <depend>message_filters</depend>
+  <depend>move_base_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>nodelet</depend>
+  <depend>octomap_msgs</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>rosgraph_msgs</depend>
+  <depend>rospy</depend>
+  <depend>rtabmap</depend>
+  <depend>rviz</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>stereo_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf</depend>
+  <depend>tf_conversions</depend>
+  <depend>visualization_msgs</depend>
+  <exec_depend>compressed_depth_image_transport</exec_depend>
+  <exec_depend>compressed_image_transport</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>theora_image_transport</exec_depend>
 
   <export>
 	<nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/package.xml
+++ b/package.xml
@@ -52,8 +52,8 @@
   <exec_depend>theora_image_transport</exec_depend>
 
   <export>
-	<nodelet plugin="${prefix}/nodelet_plugins.xml" />
-	<rviz plugin="${prefix}/rviz_plugins.xml"/>
-	<costmap_2d plugin="${prefix}/costmap_plugins.xml"/>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
+    <rviz plugin="${prefix}/rviz_plugins.xml"/>
+    <costmap_2d plugin="${prefix}/costmap_plugins.xml"/>
   </export>
 </package>


### PR DESCRIPTION
I was trying to grasp which dependencies where required for `rtabmap_ros`. 

Almost all of them where listed as `<build_depend>` **and** `<run depend>`. This can be a single `<depend>`.

I took the liberty of cleaning these, so it is quickly clear which dependencies are only runtime.