### PR TITLE
use class_list_macros.hpp and class_loader.hpp instead of deprecated .h

### DIFF
--- a/src/CoreWrapper.cpp
+++ b/src/CoreWrapper.cpp
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 #include <ros/ros.h>
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 
 #include <nav_msgs/Path.h>
 #include <std_msgs/Int32MultiArray.h>

--- a/src/costmap_2d/static_layer.cpp
+++ b/src/costmap_2d/static_layer.cpp
@@ -42,7 +42,7 @@
 
 #include "static_layer.h"
 #include <costmap_2d/costmap_math.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(rtabmap_ros::StaticLayer, costmap_2d::Layer)
 

--- a/src/costmap_2d/voxel_layer.cpp
+++ b/src/costmap_2d/voxel_layer.cpp
@@ -36,7 +36,7 @@
  *         David V. Lu!!
  *********************************************************************/
 #include "voxel_layer.h"
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <boost/thread.hpp>
 #include <pcl_conversions/pcl_conversions.h>

--- a/src/nodelets/data_odom_sync.cpp
+++ b/src/nodelets/data_odom_sync.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "ros/ros.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 #include "nodelet/nodelet.h"
 
 #include <message_filters/subscriber.h>

--- a/src/nodelets/data_throttle.cpp
+++ b/src/nodelets/data_throttle.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "ros/ros.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 #include "nodelet/nodelet.h"
 
 #include <message_filters/subscriber.h>

--- a/src/nodelets/disparity_to_depth.cpp
+++ b/src/nodelets/disparity_to_depth.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <sensor_msgs/Image.h>

--- a/src/nodelets/icp_odometry.cpp
+++ b/src/nodelets/icp_odometry.cpp
@@ -27,8 +27,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rtabmap_ros/OdometryROS.h>
 
-#include <pluginlib/class_list_macros.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_list_macros.hpp>
+#include <pluginlib/class_loader.hpp>
 
 #include <nodelet/nodelet.h>
 

--- a/src/nodelets/imu_to_tf.cpp
+++ b/src/nodelets/imu_to_tf.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 #include <sensor_msgs/Imu.h>
 #include <tf/transform_broadcaster.h>

--- a/src/nodelets/lidar_deskewing.cpp
+++ b/src/nodelets/lidar_deskewing.cpp
@@ -1,6 +1,6 @@
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <tf/transform_listener.h>

--- a/src/nodelets/obstacles_detection.cpp
+++ b/src/nodelets/obstacles_detection.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <pcl/point_cloud.h>

--- a/src/nodelets/obstacles_detection_old.cpp
+++ b/src/nodelets/obstacles_detection_old.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <pcl/point_cloud.h>

--- a/src/nodelets/point_cloud_aggregator.cpp
+++ b/src/nodelets/point_cloud_aggregator.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <pcl/point_cloud.h>

--- a/src/nodelets/point_cloud_assembler.cpp
+++ b/src/nodelets/point_cloud_assembler.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <pcl/point_cloud.h>

--- a/src/nodelets/point_cloud_xyz.cpp
+++ b/src/nodelets/point_cloud_xyz.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <rtabmap_ros/MsgConversion.h>

--- a/src/nodelets/point_cloud_xyzrgb.cpp
+++ b/src/nodelets/point_cloud_xyzrgb.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <pcl/point_cloud.h>

--- a/src/nodelets/pointcloud_to_depthimage.cpp
+++ b/src/nodelets/pointcloud_to_depthimage.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 #include <ros/publisher.h>
 #include <ros/subscriber.h>

--- a/src/nodelets/rgb_sync.cpp
+++ b/src/nodelets/rgb_sync.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <sensor_msgs/Image.h>

--- a/src/nodelets/rgbd_odometry.cpp
+++ b/src/nodelets/rgbd_odometry.cpp
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rtabmap_ros/OdometryROS.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <message_filters/subscriber.h>

--- a/src/nodelets/rgbd_relay.cpp
+++ b/src/nodelets/rgbd_relay.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <sensor_msgs/Image.h>

--- a/src/nodelets/rgbd_split.cpp
+++ b/src/nodelets/rgbd_split.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <sensor_msgs/Image.h>

--- a/src/nodelets/rgbd_sync.cpp
+++ b/src/nodelets/rgbd_sync.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <sensor_msgs/Image.h>

--- a/src/nodelets/rgbdicp_odometry.cpp
+++ b/src/nodelets/rgbdicp_odometry.cpp
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rtabmap_ros/OdometryROS.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <message_filters/subscriber.h>

--- a/src/nodelets/rgbdx_sync.cpp
+++ b/src/nodelets/rgbdx_sync.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <message_filters/sync_policies/approximate_time.h>

--- a/src/nodelets/stereo_odometry.cpp
+++ b/src/nodelets/stereo_odometry.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "rtabmap_ros/OdometryROS.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 #include "nodelet/nodelet.h"
 
 #include <message_filters/subscriber.h>

--- a/src/nodelets/stereo_sync.cpp
+++ b/src/nodelets/stereo_sync.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <sensor_msgs/Image.h>

--- a/src/nodelets/stereo_throttle.cpp
+++ b/src/nodelets/stereo_throttle.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "ros/ros.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_list_macros.hpp"
 #include "nodelet/nodelet.h"
 
 #include <message_filters/subscriber.h>

--- a/src/nodelets/undistort_depth.cpp
+++ b/src/nodelets/undistort_depth.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include <sensor_msgs/Image.h>

--- a/src/rviz/InfoDisplay.cpp
+++ b/src/rviz/InfoDisplay.cpp
@@ -127,5 +127,5 @@ void InfoDisplay::reset()
 
 } // namespace rtabmap_ros
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rtabmap_ros::InfoDisplay, rviz::Display )

--- a/src/rviz/MapCloudDisplay.cpp
+++ b/src/rviz/MapCloudDisplay.cpp
@@ -992,5 +992,5 @@ bool MapCloudDisplay::transformCloud(const CloudInfoPtr& cloud_info, bool update
 
 } // namespace rtabmap
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rtabmap_ros::MapCloudDisplay, rviz::Display )

--- a/src/rviz/MapCloudDisplay.h
+++ b/src/rviz/MapCloudDisplay.h
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap_ros/MapData.h>
 #include <rtabmap/core/Transform.h>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <sensor_msgs/PointCloud2.h>
 
 #include <ros/callback_queue.h>

--- a/src/rviz/MapGraphDisplay.cpp
+++ b/src/rviz/MapGraphDisplay.cpp
@@ -182,5 +182,5 @@ void MapGraphDisplay::processMessage( const rtabmap_ros::MapGraph::ConstPtr& msg
 
 } // namespace rtabmap_ros
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rtabmap_ros::MapGraphDisplay, rviz::Display )

--- a/src/rviz/OrbitOrientedViewController.cpp
+++ b/src/rviz/OrbitOrientedViewController.cpp
@@ -72,5 +72,5 @@ void OrbitOrientedViewController::updateCamera()
 
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rtabmap_ros::OrbitOrientedViewController, rviz::ViewController )


### PR DESCRIPTION
In more recent releases of pluginlib (including what is apt installable in Ubuntu 22.10) the deprecated class_loader.h and class_macro_lists.h finally were removed