### PR TITLE
build rtabmap_viz with Qt5 on Ubuntu 22.10

### DIFF
--- a/rtabmap_costmap_plugins/CMakeLists.txt
+++ b/rtabmap_costmap_plugins/CMakeLists.txt
@@ -5,7 +5,7 @@ project(rtabmap_costmap_plugins)
 ## Dependencies ##
 ##################
 
-find_package(catkin REQUIRED COMPONENTS roscpp pcl_conversions costmap_2d)
+find_package(catkin REQUIRED COMPONENTS dynamic_reconfigure roscpp pcl_conversions costmap_2d)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/rtabmap_costmap_plugins/package.xml
+++ b/rtabmap_costmap_plugins/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>genmsg</buildtool_depend>
 
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>message_generation</build_depend>
   <depend>costmap_2d</depend>

--- a/rtabmap_demos/package.xml
+++ b/rtabmap_demos/package.xml
@@ -16,7 +16,11 @@
   <depend>rtabmap_msgs</depend>
 
   <exec_depend>rtabmap_costmap_plugins</exec_depend>
-  <exec_depend>rtabmap_legacy</exec_depend>
+  <exec_depend>rtabmap_launch</exec_depend>
+  <!--exec_depend>rtabmap_legacy</exec_depend-->
+  <exec_depend>rtabmap_odom</exec_depend>
+  <exec_depend>rtabmap_slam</exec_depend>
+  <exec_depend>rtabmap_sync</exec_depend>
   <exec_depend>rtabmap_rviz_plugins</exec_depend>
   <exec_depend>rtabmap_viz</exec_depend>
   <exec_depend>rtabmap_util</exec_depend>

--- a/rtabmap_demos/package.xml
+++ b/rtabmap_demos/package.xml
@@ -17,7 +17,6 @@
 
   <exec_depend>rtabmap_costmap_plugins</exec_depend>
   <exec_depend>rtabmap_legacy</exec_depend>
-  <exec_depend>rtabmap_ros</exec_depend>
   <exec_depend>rtabmap_rviz_plugins</exec_depend>
   <exec_depend>rtabmap_viz</exec_depend>
   <exec_depend>rtabmap_util</exec_depend>

--- a/rtabmap_examples/package.xml
+++ b/rtabmap_examples/package.xml
@@ -16,7 +16,6 @@
 
   <exec_depend>rtabmap_costmap_plugins</exec_depend>
   <exec_depend>rtabmap_msgs</exec_depend>
-  <exec_depend>rtabmap_ros</exec_depend>
   <exec_depend>rtabmap_rviz_plugins</exec_depend>
   <exec_depend>rtabmap_viz</exec_depend>
   <exec_depend>rtabmap_demos</exec_depend>

--- a/rtabmap_examples/package.xml
+++ b/rtabmap_examples/package.xml
@@ -15,8 +15,12 @@
   <depend>rtabmap_conversions</depend>
 
   <exec_depend>rtabmap_costmap_plugins</exec_depend>
+  <exec_depend>rtabmap_launch</exec_depend>
   <exec_depend>rtabmap_msgs</exec_depend>
+  <exec_depend>rtabmap_odom</exec_depend>
   <exec_depend>rtabmap_rviz_plugins</exec_depend>
+  <exec_depend>rtabmap_slam</exec_depend>
+  <exec_depend>rtabmap_util</exec_depend>
   <exec_depend>rtabmap_viz</exec_depend>
   <exec_depend>rtabmap_demos</exec_depend>
   

--- a/rtabmap_launch/CMakeLists.txt
+++ b/rtabmap_launch/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(rtabmap_launch)
 
+find_package(catkin REQUIRED COMPONENTS
+)
+
 catkin_package()
 
 #############

--- a/rtabmap_launch/package.xml
+++ b/rtabmap_launch/package.xml
@@ -13,7 +13,10 @@
 
   <exec_depend>rtabmap_costmap_plugins</exec_depend>
   <exec_depend>rtabmap_msgs</exec_depend>
+  <exec_depend>rtabmap_odom</exec_depend>
   <exec_depend>rtabmap_rviz_plugins</exec_depend>
+  <exec_depend>rtabmap_slam</exec_depend>
+  <exec_depend>rtabmap_util</exec_depend>
   <exec_depend>rtabmap_viz</exec_depend>
 
 </package>

--- a/rtabmap_launch/package.xml
+++ b/rtabmap_launch/package.xml
@@ -13,7 +13,6 @@
 
   <exec_depend>rtabmap_costmap_plugins</exec_depend>
   <exec_depend>rtabmap_msgs</exec_depend>
-  <exec_depend>rtabmap_ros</exec_depend>
   <exec_depend>rtabmap_rviz_plugins</exec_depend>
   <exec_depend>rtabmap_viz</exec_depend>
 

--- a/rtabmap_legacy/package.xml
+++ b/rtabmap_legacy/package.xml
@@ -11,11 +11,24 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>dynamic_reconfigure</depend>
-  <depend>image_transport</depend>
-  <depend>nodelet</depend>
-  <depend>rtabmap_conversions</depend>
-  <depend>rtabmap_msgs</depend>
+  <build_export_depend>rtabmap_conversions</build_export_depend>
+  <build_export_depend>rtabmap_msgs</build_export_depend>
+
+  <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>rtabmap_conversions</build_depend>
+  <build_depend>rtabmap_msgs</build_depend>
+
+  <exec_depend>dynamic_reconfigure</exec_depend>
+  <exec_depend>image_transport</exec_depend>
+  <exec_depend>nodelet</exec_depend>
+  <exec_depend>rtabmap_conversions</exec_depend>
+  <exec_depend>rtabmap_demos</exec_depend>
+  <exec_depend>rtabmap_launch</exec_depend>
+  <exec_depend>rtabmap_msgs</exec_depend>
+  <exec_depend>rtabmap_odom</exec_depend>
+  <exec_depend>rtabmap_slam</exec_depend>
+  <exec_depend>rtabmap_viz</exec_depend>
   
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/rtabmap_msgs/CMakeLists.txt
+++ b/rtabmap_msgs/CMakeLists.txt
@@ -6,7 +6,7 @@ project(rtabmap_msgs)
 ##################
 
 find_package(catkin REQUIRED COMPONENTS
-             std_msgs std_srvs geometry_msgs sensor_msgs genmsg
+             message_generation std_msgs std_srvs geometry_msgs sensor_msgs genmsg
 )
 
 #######################################

--- a/rtabmap_ros/CMakeLists.txt
+++ b/rtabmap_ros/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(rtabmap_ros)
 
+find_package(catkin REQUIRED COMPONENTS
+)
+
 catkin_package()
 
 #############

--- a/rtabmap_ros/package.xml
+++ b/rtabmap_ros/package.xml
@@ -20,7 +20,6 @@
   <exec_depend>rtabmap_launch</exec_depend>
   <exec_depend>rtabmap_legacy</exec_depend>
   <exec_depend>rtabmap_msgs</exec_depend>
-  <exec_depend>rtabmap_odometry</exec_depend>
   <exec_depend>rtabmap_legacy</exec_depend>
   <exec_depend>rtabmap_python</exec_depend>
   <exec_depend>rtabmap_rviz_plugins</exec_depend>

--- a/rtabmap_viz/CMakeLists.txt
+++ b/rtabmap_viz/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(rtabmap_viz)
 
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
-
 find_package(catkin REQUIRED COMPONENTS
              cv_bridge geometry_msgs std_msgs std_srvs nav_msgs rtabmap_msgs rtabmap_sync tf
 )
@@ -28,8 +26,6 @@ ENDIF(NOT Qt5_FOUND)
 ###########
 ## Build ##
 ###########
-
-include_directories(${Qt5Widgets_INCLUDE_DIRS})
 
 # include_directories(include)
 include_directories(

--- a/rtabmap_viz/CMakeLists.txt
+++ b/rtabmap_viz/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(rtabmap_viz)
 
-
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
              cv_bridge geometry_msgs std_msgs std_srvs nav_msgs rtabmap_msgs rtabmap_sync tf
@@ -20,6 +20,8 @@ catkin_package(
 ## Build ##
 ###########
 
+include_directories(${Qt5Widgets_INCLUDE_DIRS})
+
 # include_directories(include)
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -27,6 +29,7 @@ include_directories(
 )
 
 add_executable(rtabmap_viz src/GuiNode.cpp src/GuiWrapper.cpp src/PreferencesDialogROS.cpp)
+target_compile_options(rtabmap_viz PRIVATE -fPIC)
 target_link_libraries(rtabmap_viz ${catkin_LIBRARIES})
 
 


### PR DESCRIPTION
I just tried building latest on Ubuntu 22.10 and got

```
In file included from /home/lucasw/base_catkin_ws/src/other/rtabmap_ros/rtabmap_viz/include/rtabmap_viz/PreferencesDialogROS.h:32,
                 from /home/lucasw/base_catkin_ws/src/other/rtabmap_ros/rtabmap_viz/src/PreferencesDialogROS.cpp:28:
/home/lucasw/base_catkin_ws/devel/include/rtabmap-0.21/rtabmap/gui/PreferencesDialog.h:33:10: fatal error: QDialog: No such file or directory
   33 | #include <QDialog>
      |          ^~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/rtabmap_viz.dir/build.make:104: CMakeFiles/rtabmap_viz.dir/src/PreferencesDialogROS.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/home/lucasw/base_catkin_ws/src/other/rtabmap_ros/rtabmap_viz/src/GuiNode.cpp:31:10: fatal error: QApplication: No such file or directory
   31 | #include <QApplication>
      |          ^~~~~~~~~~~~~~
compilation terminated.
/home/lucasw/base_catkin_ws/src/other/rtabmap_ros/rtabmap_viz/src/GuiWrapper.cpp:29:10: fatal error: QApplication: No such file or directory
   29 | #include <QApplication>
      |          ^~~~~~~~~~~~
```

I added `find_package(Qt5 COMPONENTS Widgets REQUIRED)` and `include_directories(${Qt5Widgets_INCLUDE_DIRS})` but got this:

```
/usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1281:4: error: #error "You must build your code with position independent code if Qt was built with -reduce-relocations. " "Compile your code with -fPIC (and not with -fPIE)."
 1281 | #  error "You must build your code with position independent code if Qt was built with -reduce-relocations. "\
```

Adding `target_compile_options(rtabmap_viz PRIVATE -fPIC)` looks to work to fix that, the application runs:

```
rosrun rtabmap_viz rtabmap_viz
```


I'm guessing the same qt4 + qt5 support in rtabmap_rviz_plugins/CMakeLists.txt is needed here instead of just qt5