### PR TITLE
Add dependency on nav_msgs

### DIFF
--- a/rtabmap_util/CMakeLists.txt
+++ b/rtabmap_util/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(rtabmap_util)
 
 find_package(catkin REQUIRED COMPONENTS
-             cv_bridge image_transport roscpp sensor_msgs std_msgs    
+             cv_bridge image_transport roscpp nav_msgs sensor_msgs std_msgs
              tf laser_geometry pcl_conversions pcl_ros nodelet message_filters
              pluginlib rtabmap_msgs rtabmap_conversions
 )
@@ -18,7 +18,7 @@ ENDIF(octomap_msgs_FOUND)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES rtabmap_util_plugins
-  CATKIN_DEPENDS cv_bridge image_transport roscpp sensor_msgs std_msgs    
+  CATKIN_DEPENDS cv_bridge image_transport roscpp nav_msgs sensor_msgs std_msgs
              tf laser_geometry pcl_conversions pcl_ros nodelet message_filters
              pluginlib rtabmap_msgs rtabmap_conversions ${optional_dependencies}
 )

--- a/rtabmap_util/package.xml
+++ b/rtabmap_util/package.xml
@@ -14,6 +14,7 @@
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
   <depend>roscpp</depend>
+  <depend>nav_msgs</depend>
   <depend>octomap_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
This adds a missing dependency on nav_msgs to `rtabmap_utils`. This seems to be causing a build failure on ~all~ 2 out of 3 platforms on the buildfarm.

https://build.ros.org/job/Nbin_uF64__rtabmap_util__ubuntu_focal_amd64__binary/2/console


```
23:14:12 [ 20%] Building CXX object CMakeFiles/rtabmap_data_player.dir/src/DbPlayerNode.cpp.o
23:14:12 /usr/lib/ccache/c++  -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"rtabmap_util\" -DWITH_OCTOMAP_MSGS -I/tmp/binarydeb/ros-noetic-rtabmap-util-0.21.1/include -I/opt/ros/noetic/include -I/opt/ros/noetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp -I/opt/ros/noetic/include/rtabmap-0.21 -I/usr/include/opencv4 -I/usr/include/eigen3 -I/usr/include/pcl-1.10 -I/usr/include/vtk-7.1 -I/usr/include/freetype2 -I/usr/include/ni -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -I/usr/include/x86_64-linux-gnu/qt5/QtOpenGL  -g -O2 -fdebug-prefix-map=/tmp/binarydeb/ros-noetic-rtabmap-util-0.21.1=. -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2   -o CMakeFiles/rtabmap_data_player.dir/src/DbPlayerNode.cpp.o -c /tmp/binarydeb/ros-noetic-rtabmap-util-0.21.1/src/DbPlayerNode.cpp
23:14:12 /tmp/binarydeb/ros-noetic-rtabmap-util-0.21.1/src/DbPlayerNode.cpp:38:10: fatal error: nav_msgs/Odometry.h: No such file or directory
23:14:16    38 | #include <nav_msgs/Odometry.h>
23:14:16       |          ^~~~~~~~~~~~~~~~~~~~~
23:14:16 compilation terminated.
```