### PR TITLE
Two and three D405 examples

### DIFF
--- a/docker/noetic/superpoint/Dockerfile
+++ b/docker/noetic/superpoint/Dockerfile
@@ -1,0 +1,146 @@
+# Image built with pytorch/CUDA support (SuperPoint, SuperGlue, OpenCV+nonfree+xfeatures2d)
+#
+#
+# Create image:
+#
+# cd rtabmap_ros
+# docker build -t rtabmap_ros:superpoint -f docker/noetic/superpoint/Dockerfile .
+#
+#
+#
+# Example of usage (using superpoint + superglue for loop closure detection) with D435i:
+#
+# [Camera]
+# docker run -it --rm --network host --privileged rtabmap_ros:superpoint roslaunch realsense2_camera rs_camera.launch enable_infra1:=true enable_infra2:=true unite_imu_method:=linear_interpolation enable_gyro:=true enable_accel:=true enable_sync:=true
+#
+# [IMU filter]
+# docker run -it --rm --network host rtabmap_ros:superpoint rosrun imu_filter_madgwick imu_filter_node _use_mag:=false _publish_tf:=false _world_frame:="enu" /imu/data_raw:=/camera/imu /imu/data:=/rtabmap/imu
+#
+# [VSLAM]
+# docker run -it --rm --user $UID -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all --runtime=nvidia -e ROS_HOME=/tmp/.ros --network host -v ~/.ros:/tmp/.ros rtabmap_ros:superpoint roslaunch rtabmap_launch rtabmap.launch rtabmap_viz:=false database_path:=/tmp/.ros/rtabmap.db rtabmap_args:="--delete_db_on_start --SuperPoint/ModelPath /workspace/superpoint_v1.pt --PyMatcher/Path /workspace/SuperGluePretrainedNetwork/rtabmap_superglue.py --Kp/DetectorStrategy 11 --Vis/CorNNType 6 --Reg/RepeatOnce false --Vis/CorGuessWinSize 0" odom_args:="--Vis/CorNNType 1 --Reg/RepeatOnce true --Vis/CorGuessWinSize 40" left_image_topic:=/camera/infra1/image_rect_raw right_image_topic:=/camera/infra2/image_rect_raw left_camera_info_topic:=/camera/infra1/camera_info right_camera_info_topic:=/camera/infra2/camera_info stereo:=true wait_imu_to_init:=true imu_topic:=/rtabmap/imu
+#
+# [Visualization - optional]
+# XAUTH=/tmp/.docker.xauth
+# touch $XAUTH
+# xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+# docker run -it --rm --privileged -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all -e XAUTHORITY=$XAUTH --runtime=nvidia --network host -v $XAUTH:$XAUTH -v /tmp/.X11-unix:/tmp/.X11-unix rtabmap_ros:superpoint /bin/bash -c "export ROS_NAMESPACE=rtabmap && rosrun rtabmap_viz rtabmap_viz _subscribe_odom_info:=true left/image_rect:=/camera/infra1/image_rect_raw right/image_rect:=/camera/infra2/image_rect_raw left/camera_info:=/camera/infra1/camera_info right/camera_info:=/camera/infra2/camera_info _subscribe_stereo:=true"
+#
+FROM nvcr.io/nvidia/pytorch:22.08-py3
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+      libsqlite3-dev \
+      git \
+      cmake \
+      libyaml-cpp-dev \
+      software-properties-common \
+      pkg-config \ 
+      wget \
+      curl \
+      libpdal-dev && \
+      apt-get clean && rm -rf /var/lib/apt/lists/
+
+# Install ros keys
+RUN apt update && \
+    sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' && \
+    curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
+# Install ros dependencies
+RUN apt-get update && \
+    apt upgrade -y && \
+    apt-get install -y git ros-noetic-ros-base python3-catkin-tools python3-rosdep build-essential ros-noetic-rtabmap-ros && \
+    apt-get remove -y ros-noetic-rtabmap && \
+    rosdep init && \
+    apt-get clean && rm -rf /var/lib/apt/lists/
+
+# GTSAM
+RUN add-apt-repository ppa:borglab/gtsam-release-4.0 && \
+    apt install -y libgtsam-dev libgtsam-unstable-dev
+
+# MRPT
+RUN add-apt-repository ppa:joseluisblancoc/mrpt-stable -y && \
+    apt-get update && apt install libmrpt-poses-dev -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/
+
+# OpenCV with xfeatures2d, cuda and nonfree modules (use same version used by noetic to avoid cv_bridge conflicts)
+RUN git clone https://github.com/opencv/opencv_contrib.git && \
+    git clone https://github.com/opencv/opencv.git && \
+    cd opencv_contrib && \
+    git checkout tags/4.2.0 && \
+    cd /workspace && \
+    cd opencv && \
+    git checkout tags/4.2.0 && \
+    mkdir build && \
+    cd build && \
+    cmake -DOPENCV_EXTRA_MODULES_PATH=/workspace/opencv_contrib/modules -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DOPENCV_ENABLE_NONFREE=ON .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd /workspace && \
+    rm -rf opencv opencv_contrib
+
+# OpenGV
+RUN git clone https://github.com/laurentkneip/opengv.git && \
+    cd opengv && \
+    git checkout 91f4b19c73450833a40e463ad3648aae80b3a7f3 && \
+    wget https://gist.githubusercontent.com/matlabbe/a412cf7c4627253874f81a00745a7fbb/raw/accc3acf465d1ffd0304a46b17741f62d4d354ef/opengv_disable_march_native.patch && \
+    git apply opengv_disable_march_native.patch && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd /workspace && \
+    rm -r opengv
+
+# Setup ROS entrypoint
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+COPY ./docker/noetic/superpoint/ros_entrypoint.sh /ros_entrypoint.sh
+RUN chmod +x /ros_entrypoint.sh
+ENTRYPOINT [ "/ros_entrypoint.sh" ]
+
+# Get rtabmap library
+# Create Superpoint model with current pytorch version
+# Setup Superglue
+#Build/install rtabmap library
+RUN git clone https://github.com/introlab/rtabmap rtabmap && \
+    cd rtabmap/archive/2022-IlluminationInvariant/scripts && \
+    wget https://github.com/magicleap/SuperPointPretrainedNetwork/raw/master/superpoint_v1.pth && \
+    wget https://raw.githubusercontent.com/magicleap/SuperPointPretrainedNetwork/master/demo_superpoint.py && \
+    python3 trace.py && \
+    mv superpoint_v1.pt /workspace/. && \
+    cd /workspace && \
+    git clone https://github.com/magicleap/SuperGluePretrainedNetwork && \
+    cp rtabmap/corelib/src/python/rtabmap_superglue.py SuperGluePretrainedNetwork/. && \
+    source /ros_entrypoint.sh && \
+    cd rtabmap/build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic -DTorch_DIR=/opt/conda/lib/python3.8/site-packages/torch/share/cmake/Torch -DWITH_TORCH=ON -DWITH_PYTHON=ON .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && \
+    rm -rf rtabmap && \
+    ldconfig
+
+# Setup catkin workspace
+RUN source /ros_entrypoint.sh && \
+    mkdir -p catkin_ws/src && \
+    cd catkin_ws && \
+    catkin init && \
+    catkin config --install --install-space /opt/ros/noetic
+
+COPY . catkin_ws/src/rtabmap_ros
+
+# build packages
+RUN source /ros_entrypoint.sh && \
+    cd catkin_ws && \
+    apt update && \
+    rosdep update && \
+    rosdep install --from-paths src --ignore-src -y && \
+    apt remove ros-$ROS_DISTRO-rtabmap* -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/ && \
+    catkin build --cmake-args -DPYTHON_EXECUTABLE=/usr/bin/python3 -DRTABMAP_SYNC_MULTI_RGBD=ON && \
+    cd /workspace && \
+    rm -rf catkin_ws
+

--- a/docker/noetic/superpoint/ros_entrypoint.sh
+++ b/docker/noetic/superpoint/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/noetic/setup.bash" --
+exec "$@"

--- a/rtabmap_examples/launch/config/slam_D405x2_config.rviz
+++ b/rtabmap_examples/launch/config/slam_D405x2_config.rviz
@@ -1,0 +1,434 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /TF1/Frames1
+        - /TF1/Tree1
+      Splitter Ratio: 0.5340050458908081
+    Tree Height: 413
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: MapCloud
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2 Vorne
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera1/depth/color/points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2 Oben
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera2/depth/color/points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        base_link:
+          Value: true
+        camera1_color_frame:
+          Value: true
+        camera1_color_optical_frame:
+          Value: true
+        camera1_depth_frame:
+          Value: true
+        camera1_depth_optical_frame:
+          Value: true
+        camera1_link:
+          Value: true
+        camera2_color_frame:
+          Value: true
+        camera2_color_optical_frame:
+          Value: true
+        camera2_depth_frame:
+          Value: true
+        camera2_depth_optical_frame:
+          Value: true
+        camera2_link:
+          Value: true
+        map:
+          Value: true
+        odom:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        map:
+          odom:
+            base_link:
+              camera1_link:
+                camera1_color_frame:
+                  camera1_color_optical_frame:
+                    {}
+                camera1_depth_frame:
+                  camera1_depth_optical_frame:
+                    {}
+              camera2_link:
+                camera2_color_frame:
+                  camera2_color_optical_frame:
+                    {}
+                camera2_depth_frame:
+                  camera2_depth_optical_frame:
+                    {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rtabmap_rviz_plugins/MapCloud
+      Cloud decimation: 4
+      Cloud from scan: false
+      Cloud max depth (m): 4
+      Cloud min depth (m): 0
+      Cloud voxel size (m): 0.009999999776482582
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Download graph: false
+      Download map: false
+      Download namespace: rtabmap
+      Enabled: true
+      Filter ceiling (m): 0
+      Filter floor (m): 0
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: MapCloud
+      Node filtering angle (degrees): 30
+      Node filtering radius (m): 0
+      Position Transformer: XYZ
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /rtabmap/mapData
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Camera1 Cloud
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /voxel_cloud1
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Camera2 Cloud
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /voxel_cloud2
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera1/color/image_rect_raw
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera2/color/image_rect_raw
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /rtabmap/odom_local_map
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 3.691277027130127
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.1845460832118988
+        Y: 1.409915566444397
+        Z: 0.6871283054351807
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.13479618728160858
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.8135828971862793
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1136
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000018f000003d2fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000228000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000026b000000d10000002800fffffffb0000000a0049006d0061006700650100000342000000cd0000002800ffffff000000010000010f000003d2fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000003d2000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007360000003efc0100000002fb0000000800540069006d0065010000000000000736000002fb00fffffffb0000000800540069006d006501000000000000045000000000000000000000048c000003d200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1846
+  X: 1994
+  Y: 27

--- a/rtabmap_examples/launch/config/slam_D405x3_config.rviz
+++ b/rtabmap_examples/launch/config/slam_D405x3_config.rviz
@@ -1,0 +1,538 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /TF1/Frames1
+      Splitter Ratio: 0.5340050458908081
+    Tree Height: 308
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2 Vorne
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2 Vorne
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera/depth/color/points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2 Oben
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera1/depth/color/points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2 Unten
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera2/depth/color/points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        base_link:
+          Value: true
+        camera1_color_frame:
+          Value: true
+        camera1_color_optical_frame:
+          Value: true
+        camera1_depth_frame:
+          Value: true
+        camera1_depth_optical_frame:
+          Value: true
+        camera1_link:
+          Value: true
+        camera2_color_frame:
+          Value: true
+        camera2_color_optical_frame:
+          Value: true
+        camera2_depth_frame:
+          Value: true
+        camera2_depth_optical_frame:
+          Value: true
+        camera2_link:
+          Value: true
+        camera_color_frame:
+          Value: true
+        camera_color_optical_frame:
+          Value: true
+        camera_depth_frame:
+          Value: true
+        camera_depth_optical_frame:
+          Value: true
+        camera_link:
+          Value: true
+        map:
+          Value: true
+        odom:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        map:
+          {}
+        odom:
+          base_link:
+            camera1_link:
+              camera1_color_frame:
+                camera1_color_optical_frame:
+                  {}
+              camera1_depth_frame:
+                camera1_depth_optical_frame:
+                  {}
+            camera2_link:
+              camera2_color_frame:
+                camera2_color_optical_frame:
+                  {}
+              camera2_depth_frame:
+                camera2_depth_optical_frame:
+                  {}
+            camera_link:
+              camera_color_frame:
+                camera_color_optical_frame:
+                  {}
+              camera_depth_frame:
+                camera_depth_optical_frame:
+                  {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rtabmap_rviz_plugins/MapCloud
+      Cloud decimation: 4
+      Cloud from scan: false
+      Cloud max depth (m): 4
+      Cloud min depth (m): 0
+      Cloud voxel size (m): 0.009999999776482582
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Download graph: false
+      Download map: false
+      Download namespace: rtabmap
+      Enabled: true
+      Filter ceiling (m): 0
+      Filter floor (m): 0
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: MapCloud
+      Node filtering angle (degrees): 30
+      Node filtering radius (m): 0
+      Position Transformer: XYZ
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /rtabmap/mapData
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Vorne Cloud
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /voxel_cloud1
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Oben Cloud
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /voxel_cloud2
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Unten Cloud
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /voxel_cloud3
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Img Vorne
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera/color/image_rect_raw
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Img Oben
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera1/color/image_rect_raw
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Img Unten
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera2/color/image_rect_raw
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Odom Local Map Vorne
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /rtabmap/odom_local_map
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 14.454187393188477
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.5812196135520935
+        Y: 1.577770709991455
+        Z: 0.7642305493354797
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.21979624032974243
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.493584394454956
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1163
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Img Oben:
+    collapsed: false
+  Img Unten:
+    collapsed: false
+  Img Vorne:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000018f000003edfc020000000cfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000001bf000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000120049006d006700200056006f00720065006e010000022e000000800000000000000000fb000000120049006d006700200056006f0072006e00650100000202000000930000002800fffffffb000000100049006d00670020004f00620065006e010000029b000000bb0000002800fffffffb000000120049006d006700200055006e00740065006e010000035c000000ce0000002800ffffff000000010000010f000003edfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000003ed000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002fb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004d6000003ed00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1920
+  X: 1920
+  Y: 0

--- a/rtabmap_examples/launch/rtabmap_D405x2.launch.py
+++ b/rtabmap_examples/launch/rtabmap_D405x2.launch.py
@@ -1,0 +1,305 @@
+# Program dedicated to launch 2 realsense cameras.
+# Rtabmap, the slam components and some general default parameters are considered here for the user (they can be modifed).
+# The rtabmap.launch.py example was taken as a reference, and then two camera nodes were adapted.
+# (Please note that this program can manage maximum 4 depth cameras)
+
+# Program modified by: Adrian Ricardez (https://github.com/adricort)
+# Date: 07.07.2023
+# Deutsches Zentrum für Luft- und Raumfahrt
+
+# Requirements:
+
+# Launching the 2 realsense cameras (change your serial numbers):
+#   $ ros2 launch realsense2_camera rs_multi_camera_launch.py pointcloud.enable1:=true pointcloud.enable2:=true filters:=colorizer align_depth:=true serial_no1:=_128422271521 serial_no2:=_128422272518
+
+# Running the static publishers depending on the position of your cameras:
+#   $ ros2 run tf2_ros static_transform_publisher --x 0.039 --y 0 --z 0 --yaw 0 --pitch 0 --roll 1.5708 --frame-id base_link --child-frame-id camera1_link
+#   $ ros2 run tf2_ros static_transform_publisher --x -0 --y 0 --z 0.02 --yaw 1.5708 --pitch -1.5708 --roll 0 --frame-id base_link --child-frame-id camera2_link
+
+#   $ ros2 launch rtabmap_examples rtabmap_D405x2.launch.py rtabmap_args:="--delete_db_on_start" rgb_topic1:=/camera1/color/image_rect_raw depth_topic1:=/camera1/depth/image_rect_raw camera_info_topic1:=/camera1/color/camera_info rgb_topic2:=/camera2/color/image_rect_raw depth_topic2:=/camera2/depth/image_rect_raw camera_info_topic2:=/camera2/color/camera_info frame_id:=base_link rgbd_sync:=true subscribe_rgbd:=true approx_sync:=true rviz:=true
+
+# You should be able to visualize now, with the right rviz config, the two cameras SLAM
+# Have fun!
+
+import os
+
+from launch import LaunchDescription, Substitution, LaunchContext
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable, LogInfo, OpaqueFunction
+from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir, PythonExpression
+from launch.conditions import IfCondition, UnlessCondition
+from launch_ros.actions import Node
+from launch_ros.actions import SetParameter
+from typing import Text
+from ament_index_python.packages import get_package_share_directory
+
+#Based on https://answers.ros.org/question/363763/ros2-how-best-to-conditionally-include-a-prefix-in-a-launchpy-file/
+class ConditionalText(Substitution):
+    def __init__(self, text_if, text_else, condition):
+        self.text_if = text_if
+        self.text_else = text_else
+        self.condition = condition
+
+    def perform(self, context: 'LaunchContext') -> Text:
+        if self.condition == True or self.condition == 'true' or self.condition == 'True':
+            return self.text_if
+        else:
+            return self.text_else
+            
+class ConditionalBool(Substitution):
+    def __init__(self, text_if, text_else, condition):
+        self.text_if = text_if
+        self.text_else = text_else
+        self.condition = condition
+
+    def perform(self, context: 'LaunchContext') -> bool:
+        if self.condition:
+            return self.text_if
+        else:
+            return self.text_else
+            
+def launch_setup(context, *args, **kwargs):      
+               
+    return [
+        DeclareLaunchArgument('depth', default_value=ConditionalText('false', 'true', IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' == 'true'"]))._predicate_func(context)), description=''),
+        DeclareLaunchArgument('subscribe_rgb', default_value=LaunchConfiguration('depth'), description=''),
+        DeclareLaunchArgument('args',  default_value=LaunchConfiguration('rtabmap_args'), description='Can be used to pass RTAB-Map\'s parameters or other flags like --udebug and --delete_db_on_start/-d'),
+        DeclareLaunchArgument('qos_image',       default_value=LaunchConfiguration('qos'), description='Specific QoS used for image input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('qos_camera_info', default_value=LaunchConfiguration('qos'), description='Specific QoS used for camera info input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('qos_odom',        default_value=LaunchConfiguration('qos'), description='Specific QoS used for odometry input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('qos_user_data',   default_value=LaunchConfiguration('qos'), description='Specific QoS used for user input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+    
+        SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
+        # 'use_sim_time' will be set on all nodes following the line above
+
+        Node(
+            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync1', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
+            parameters=[{
+                "approx_sync": False,
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos": LaunchConfiguration('qos_image'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "depth_scale": LaunchConfiguration('depth_scale')}],
+            remappings=[
+                ("rgb/image", LaunchConfiguration('rgb_topic1')),
+                ("depth/image", LaunchConfiguration('depth_topic1')),
+                ("rgb/camera_info", LaunchConfiguration('camera_info_topic1')),
+                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
+            namespace='realsense_camera1'),
+        Node(
+            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync2', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
+            parameters=[{
+                "approx_sync": False,
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos": LaunchConfiguration('qos_image'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "depth_scale": LaunchConfiguration('depth_scale')}],
+            remappings=[
+                ("rgb/image", LaunchConfiguration('rgb_topic2')),
+                ("depth/image", LaunchConfiguration('depth_topic2')),
+                ("rgb/camera_info", LaunchConfiguration('camera_info_topic2')),
+                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
+            namespace='realsense_camera2'),
+            
+        # Relay rgbd_image
+        Node(
+            package='rtabmap_util', executable='rgbd_relay', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' != 'true'"])),
+            remappings=[
+                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
+            namespace=LaunchConfiguration('namespace')),
+        Node(
+            package='rtabmap_util', executable='rgbd_relay', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' == 'true'"])),
+            parameters=[{
+                "uncompress": True,
+                "qos": LaunchConfiguration('qos_image')}],
+            remappings=[
+                ("rgbd_image", [LaunchConfiguration('rgbd_topic'), "/compressed"]),
+                ([LaunchConfiguration('rgbd_topic'), "/compressed_relay"], LaunchConfiguration('rgbd_topic'))],
+            namespace=LaunchConfiguration('namespace')),
+                
+        # RGB-D odometry
+        Node(
+            package='rtabmap_odom', executable='rgbd_odometry', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' != 'true' and '", LaunchConfiguration('visual_odometry'), "' == 'true' and '", LaunchConfiguration('stereo'), "' != 'true'"])),
+            parameters=[{
+                "frame_id": LaunchConfiguration('frame_id'),
+                "odom_frame_id": LaunchConfiguration('vo_frame_id'),
+                "publish_tf": LaunchConfiguration('publish_tf_odom'),
+                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
+                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
+                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
+                "config_path": LaunchConfiguration('cfg').perform(context),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos": LaunchConfiguration('qos_image'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
+                "guess_frame_id": LaunchConfiguration('odom_guess_frame_id').perform(context),
+                "guess_min_translation": LaunchConfiguration('odom_guess_min_translation'),
+                "guess_min_rotation": LaunchConfiguration('odom_guess_min_rotation')}],
+            remappings=[
+                ("rgbd_image", '/realsense_camera1/rgbd_image'),
+                ("odom", LaunchConfiguration('odom_topic'))],
+            arguments=[LaunchConfiguration("args"), LaunchConfiguration("odom_args")],
+            prefix=LaunchConfiguration('launch_prefix'),
+            namespace=LaunchConfiguration('namespace')),
+
+        Node(
+            package='rtabmap_slam', executable='rtabmap', output="screen",
+            parameters=[{
+                "rgbd_cameras":2,
+                "subscribe_depth": LaunchConfiguration('depth'),
+                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
+                "subscribe_rgb": LaunchConfiguration('subscribe_rgb'),
+                "subscribe_stereo": LaunchConfiguration('stereo'),
+                "subscribe_user_data": LaunchConfiguration('subscribe_user_data'),
+                "subscribe_odom_info": ConditionalBool(True, False, IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' == 'true' or '", LaunchConfiguration('visual_odometry'), "' == 'true'"]))._predicate_func(context)).perform(context),
+                "frame_id": LaunchConfiguration('frame_id'),
+                "map_frame_id": LaunchConfiguration('map_frame_id'),
+                "odom_frame_id": LaunchConfiguration('odom_frame_id').perform(context),
+                "publish_tf": LaunchConfiguration('publish_tf_map'),
+                "initial_pose": LaunchConfiguration('initial_pose'),
+                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
+                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
+                "odom_tf_angular_variance": LaunchConfiguration('odom_tf_angular_variance'),
+                "odom_tf_linear_variance": LaunchConfiguration('odom_tf_linear_variance'),
+                "odom_sensor_sync": LaunchConfiguration('odom_sensor_sync'),
+                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
+                "database_path": LaunchConfiguration('database_path'),
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "config_path": LaunchConfiguration('cfg').perform(context),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos_image": LaunchConfiguration('qos_image'),
+                "qos_odom": LaunchConfiguration('qos_odom'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "qos_user_data": LaunchConfiguration('qos_user_data'),
+                "Mem/IncrementalMemory": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' != 'true'"]))._predicate_func(context)).perform(context),
+                "Mem/InitWMWithAllNodes": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' == 'true'"]))._predicate_func(context)).perform(context)
+            }],
+            remappings=[
+                ("rgbd_image0", '/realsense_camera1/rgbd_image'),
+                ("rgbd_image1", '/realsense_camera2/rgbd_image'),
+                ("user_data", LaunchConfiguration('user_data_topic')),
+                ("user_data_async", LaunchConfiguration('user_data_async_topic')),
+                ("odom", LaunchConfiguration('odom_topic'))],
+            arguments=[LaunchConfiguration("args")],
+            prefix=LaunchConfiguration('launch_prefix'),
+            namespace=LaunchConfiguration('namespace')),
+
+        Node(
+            package='rviz2', executable='rviz2', output='screen',
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            arguments=[["-d"], [LaunchConfiguration("rviz_cfg")]]),
+        Node(
+            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb1', output='screen',
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            parameters=[{
+                "decimation": 4,
+                "voxel_size": 0.0,
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
+            }],
+            remappings=[
+                ('rgb/image', LaunchConfiguration('rgb_topic1')),
+                ('depth/image', LaunchConfiguration('depth_topic1')),
+                ('rgb/camera_info', LaunchConfiguration('camera_info_topic1')),
+                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
+                ('cloud', 'voxel_cloud1')]),
+        Node(
+            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb2', output='screen',
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            parameters=[{
+                "decimation": 4,
+                "voxel_size": 0.0,
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
+            }],
+            remappings=[
+                ('rgb/image', LaunchConfiguration('rgb_topic2')),
+                ('depth/image', LaunchConfiguration('depth_topic2')),
+                ('rgb/camera_info', LaunchConfiguration('camera_info_topic2')),
+                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
+                ('cloud', 'voxel_cloud2')]),    
+        ]
+
+def generate_launch_description():
+    
+    config_rviz = os.path.join(
+        get_package_share_directory('rtabmap_examples'), 'launch', 'config', 'slam_D405x2_config.rviz'
+    )
+    
+    return LaunchDescription([
+        
+        # Arguments
+        DeclareLaunchArgument('stereo', default_value='false', description='Use stereo input instead of RGB-D.'),
+
+        DeclareLaunchArgument('localization', default_value='false', description='Launch in localization mode.'),
+        DeclareLaunchArgument('rtabmapviz',   default_value='false',  description='Launch RTAB-Map UI (optional).'),
+        DeclareLaunchArgument('rviz',         default_value='false', description='Launch RVIZ (optional).'),
+
+        DeclareLaunchArgument('use_sim_time', default_value='false', description='Use simulation (Gazebo) clock if true'),
+
+        # Config files
+        DeclareLaunchArgument('cfg',      default_value='',                        description='To change RTAB-Map\'s parameters, set the path of config file (*.ini) generated by the standalone app.'),
+        DeclareLaunchArgument('gui_cfg',  default_value='~/.ros/rtabmap_gui.ini',  description='Configuration path of rtabmapviz.'),
+        DeclareLaunchArgument('rviz_cfg', default_value=config_rviz,               description='Configuration path of rviz2.'),
+
+        DeclareLaunchArgument('frame_id',       default_value='base_link',          description='Fixed frame id of the robot (base frame), you may set "base_link" or "base_footprint" if they are published. For camera-only config, this could be "camera_link".'),
+        DeclareLaunchArgument('odom_frame_id',  default_value='',                   description='If set, TF is used to get odometry instead of the topic.'),
+        DeclareLaunchArgument('map_frame_id',   default_value='map',                description='Output map frame id (TF).'),
+        DeclareLaunchArgument('publish_tf_map', default_value='true',               description='Publish TF between map and odomerty.'),
+        DeclareLaunchArgument('namespace',      default_value='rtabmap',            description=''),
+        DeclareLaunchArgument('database_path',  default_value='~/.ros/rtabmap.db',  description='Where is the map saved/loaded.'),
+        DeclareLaunchArgument('queue_size',     default_value='10',                 description=''),
+        DeclareLaunchArgument('qos',            default_value='1',                  description='General QoS used for sensor input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('wait_for_transform', default_value='0.2',            description=''),
+        DeclareLaunchArgument('rtabmap_args',   default_value='',                   description='Backward compatibility, use "args" instead.'),
+        DeclareLaunchArgument('launch_prefix',  default_value='',                   description='For debugging purpose, it fills prefix tag of the nodes, e.g., "xterm -e gdb -ex run --args"'),
+        DeclareLaunchArgument('output',         default_value='screen',             description='Control node output (screen or log).'),
+        DeclareLaunchArgument('initial_pose',   default_value='',                   description='Set an initial pose (only in localization mode). Format: "x y z roll pitch yaw" or "x y z qx qy qz qw". Default: see "RGBD/StartAtOrigin" doc'),
+        
+        DeclareLaunchArgument('ground_truth_frame_id',      default_value='', description='e.g., "world"'),
+        DeclareLaunchArgument('ground_truth_base_frame_id', default_value='', description='e.g., "tracker", a fake frame matching the frame "frame_id" (but on different TF tree)'),
+        
+        DeclareLaunchArgument('approx_sync',  default_value='false',            description='If timestamps of the input topics should be synchronized using approximate or exact time policy.'),
+        DeclareLaunchArgument('approx_sync_max_interval',  default_value='0.0', description='(sec) 0 means infinite interval duration (used with approx_sync=true)'),
+        
+        # Use Pre-sync RGBDImage format
+        DeclareLaunchArgument('rgbd_sync',        default_value='false',      description='Pre-sync rgb_topic1, depth_topic, camera_info_topic1.'),
+        DeclareLaunchArgument('approx_rgbd_sync', default_value='true',       description='false=exact synchronization.'),
+        DeclareLaunchArgument('subscribe_rgbd',   default_value=LaunchConfiguration('rgbd_sync'), description='Already synchronized RGB-D related topic, e.g., with rtabmap_sync/rgbd_sync nodelet.'),
+        DeclareLaunchArgument('rgbd_topic',       default_value='rgbd_image', description=''),
+        DeclareLaunchArgument('depth_scale',      default_value='1.0',        description=''),
+        
+        # Image topic compression
+        DeclareLaunchArgument('compressed',            default_value='false', description='If you want to subscribe to compressed image topics'),
+        DeclareLaunchArgument('rgb_image_transport',   default_value='compressed', description='Common types: compressed, theora (see "rosrun image_transport list_transports")'),
+        DeclareLaunchArgument('depth_image_transport', default_value='compressedDepth', description='Depth compatible types: compressedDepth (see "rosrun image_transport list_transports")'),
+        
+        # Odometry
+        DeclareLaunchArgument('visual_odometry',            default_value='true',  description='Launch rtabmap visual odometry node.'),
+        DeclareLaunchArgument('icp_odometry',               default_value='false', description='Launch rtabmap icp odometry node.'),
+        DeclareLaunchArgument('odom_topic',                 default_value='odom',  description='Odometry topic name.'),
+        DeclareLaunchArgument('vo_frame_id',                default_value=LaunchConfiguration('odom_topic'), description='Visual/Icp odometry frame ID for TF.'),
+        DeclareLaunchArgument('publish_tf_odom',            default_value='true',  description=''),
+        DeclareLaunchArgument('odom_tf_angular_variance',   default_value='0.01',    description='If TF is used to get odometry, this is the default angular variance'),
+        DeclareLaunchArgument('odom_tf_linear_variance',    default_value='0.001',   description='If TF is used to get odometry, this is the default linear variance'),
+        DeclareLaunchArgument('odom_args',                  default_value='',      description='More arguments for odometry (overwrite same parameters in rtabmap_args).'),
+        DeclareLaunchArgument('odom_sensor_sync',           default_value='false', description=''),
+        DeclareLaunchArgument('odom_guess_frame_id',        default_value='',      description=''),
+        DeclareLaunchArgument('odom_guess_min_translation', default_value='0.0',   description=''),
+        DeclareLaunchArgument('odom_guess_min_rotation',    default_value='0.0',   description=''),
+        
+        # User Data
+        DeclareLaunchArgument('subscribe_user_data',   default_value='false',            description='User data synchronized subscription.'),
+        DeclareLaunchArgument('user_data_topic',       default_value='/user_data',       description=''),
+        DeclareLaunchArgument('user_data_async_topic', default_value='/user_data_async', description='User data async subscription (rate should be lower than map update rate).'),
+
+        OpaqueFunction(function=launch_setup)
+    ])

--- a/rtabmap_examples/launch/rtabmap_D405x2.launch.py
+++ b/rtabmap_examples/launch/rtabmap_D405x2.launch.py
@@ -1,6 +1,4 @@
-# Program dedicated to launch 2 realsense cameras.
-# Rtabmap, the slam components and some general default parameters are considered here for the user (they can be modifed).
-# The rtabmap.launch.py example was taken as a reference, and then two camera nodes were adapted.
+# Program dedicated to launch 2 realsense cameras. D405 were tested!
 # (Please note that this program can manage maximum 4 depth cameras)
 
 # Program modified by: Adrian Ricardez (https://github.com/adricort)
@@ -9,6 +7,8 @@
 
 # Requirements:
 
+# Be sure that you did the build on your rtabmap workspace with the -DRTABMAP_SYNC_MULTI_RGBD=ON parameter.
+
 # Launching the 2 realsense cameras (change your serial numbers):
 #   $ ros2 launch realsense2_camera rs_multi_camera_launch.py pointcloud.enable1:=true pointcloud.enable2:=true filters:=colorizer align_depth:=true serial_no1:=_128422271521 serial_no2:=_128422272518
 
@@ -16,290 +16,129 @@
 #   $ ros2 run tf2_ros static_transform_publisher --x 0.039 --y 0 --z 0 --yaw 0 --pitch 0 --roll 1.5708 --frame-id base_link --child-frame-id camera1_link
 #   $ ros2 run tf2_ros static_transform_publisher --x -0 --y 0 --z 0.02 --yaw 1.5708 --pitch -1.5708 --roll 0 --frame-id base_link --child-frame-id camera2_link
 
-#   $ ros2 launch rtabmap_examples rtabmap_D405x2.launch.py rtabmap_args:="--delete_db_on_start" rgb_topic1:=/camera1/color/image_rect_raw depth_topic1:=/camera1/depth/image_rect_raw camera_info_topic1:=/camera1/color/camera_info rgb_topic2:=/camera2/color/image_rect_raw depth_topic2:=/camera2/depth/image_rect_raw camera_info_topic2:=/camera2/color/camera_info frame_id:=base_link rgbd_sync:=true subscribe_rgbd:=true approx_sync:=true rviz:=true
+#   $ ros2 launch rtabmap_examples rtabmap_D405x2.launch.py
 
-# You should be able to visualize now, with the right rviz config, the two cameras SLAM
+# You should be able to visualize now, with the right rviz config, the camera's SLAM
 # Have fun!
 
 import os
-
-from launch import LaunchDescription, Substitution, LaunchContext
-from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable, LogInfo, OpaqueFunction
-from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir, PythonExpression
-from launch.conditions import IfCondition, UnlessCondition
-from launch_ros.actions import Node
-from launch_ros.actions import SetParameter
-from typing import Text
+import launch
+import launch_ros
 from ament_index_python.packages import get_package_share_directory
+          
+def generate_launch_description():     
 
-#Based on https://answers.ros.org/question/363763/ros2-how-best-to-conditionally-include-a-prefix-in-a-launchpy-file/
-class ConditionalText(Substitution):
-    def __init__(self, text_if, text_else, condition):
-        self.text_if = text_if
-        self.text_else = text_else
-        self.condition = condition
-
-    def perform(self, context: 'LaunchContext') -> Text:
-        if self.condition == True or self.condition == 'true' or self.condition == 'True':
-            return self.text_if
-        else:
-            return self.text_else
-            
-class ConditionalBool(Substitution):
-    def __init__(self, text_if, text_else, condition):
-        self.text_if = text_if
-        self.text_else = text_else
-        self.condition = condition
-
-    def perform(self, context: 'LaunchContext') -> bool:
-        if self.condition:
-            return self.text_if
-        else:
-            return self.text_else
-            
-def launch_setup(context, *args, **kwargs):      
-               
-    return [
-        DeclareLaunchArgument('depth', default_value=ConditionalText('false', 'true', IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' == 'true'"]))._predicate_func(context)), description=''),
-        DeclareLaunchArgument('subscribe_rgb', default_value=LaunchConfiguration('depth'), description=''),
-        DeclareLaunchArgument('args',  default_value=LaunchConfiguration('rtabmap_args'), description='Can be used to pass RTAB-Map\'s parameters or other flags like --udebug and --delete_db_on_start/-d'),
-        DeclareLaunchArgument('qos_image',       default_value=LaunchConfiguration('qos'), description='Specific QoS used for image input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('qos_camera_info', default_value=LaunchConfiguration('qos'), description='Specific QoS used for camera info input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('qos_odom',        default_value=LaunchConfiguration('qos'), description='Specific QoS used for odometry input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('qos_user_data',   default_value=LaunchConfiguration('qos'), description='Specific QoS used for user input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-    
-        SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
-        # 'use_sim_time' will be set on all nodes following the line above
-
-        Node(
-            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync1', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
-            parameters=[{
-                "approx_sync": False,
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos": LaunchConfiguration('qos_image'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "depth_scale": LaunchConfiguration('depth_scale')}],
-            remappings=[
-                ("rgb/image", LaunchConfiguration('rgb_topic1')),
-                ("depth/image", LaunchConfiguration('depth_topic1')),
-                ("rgb/camera_info", LaunchConfiguration('camera_info_topic1')),
-                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
-            namespace='realsense_camera1'),
-        Node(
-            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync2', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
-            parameters=[{
-                "approx_sync": False,
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos": LaunchConfiguration('qos_image'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "depth_scale": LaunchConfiguration('depth_scale')}],
-            remappings=[
-                ("rgb/image", LaunchConfiguration('rgb_topic2')),
-                ("depth/image", LaunchConfiguration('depth_topic2')),
-                ("rgb/camera_info", LaunchConfiguration('camera_info_topic2')),
-                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
-            namespace='realsense_camera2'),
-            
-        # Relay rgbd_image
-        Node(
-            package='rtabmap_util', executable='rgbd_relay', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' != 'true'"])),
-            remappings=[
-                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
-            namespace=LaunchConfiguration('namespace')),
-        Node(
-            package='rtabmap_util', executable='rgbd_relay', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' == 'true'"])),
-            parameters=[{
-                "uncompress": True,
-                "qos": LaunchConfiguration('qos_image')}],
-            remappings=[
-                ("rgbd_image", [LaunchConfiguration('rgbd_topic'), "/compressed"]),
-                ([LaunchConfiguration('rgbd_topic'), "/compressed_relay"], LaunchConfiguration('rgbd_topic'))],
-            namespace=LaunchConfiguration('namespace')),
-                
-        # RGB-D odometry
-        Node(
-            package='rtabmap_odom', executable='rgbd_odometry', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' != 'true' and '", LaunchConfiguration('visual_odometry'), "' == 'true' and '", LaunchConfiguration('stereo'), "' != 'true'"])),
-            parameters=[{
-                "frame_id": LaunchConfiguration('frame_id'),
-                "odom_frame_id": LaunchConfiguration('vo_frame_id'),
-                "publish_tf": LaunchConfiguration('publish_tf_odom'),
-                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
-                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
-                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
-                "config_path": LaunchConfiguration('cfg').perform(context),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos": LaunchConfiguration('qos_image'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
-                "guess_frame_id": LaunchConfiguration('odom_guess_frame_id').perform(context),
-                "guess_min_translation": LaunchConfiguration('odom_guess_min_translation'),
-                "guess_min_rotation": LaunchConfiguration('odom_guess_min_rotation')}],
-            remappings=[
-                ("rgbd_image", '/realsense_camera1/rgbd_image'),
-                ("odom", LaunchConfiguration('odom_topic'))],
-            arguments=[LaunchConfiguration("args"), LaunchConfiguration("odom_args")],
-            prefix=LaunchConfiguration('launch_prefix'),
-            namespace=LaunchConfiguration('namespace')),
-
-        Node(
-            package='rtabmap_slam', executable='rtabmap', output="screen",
-            parameters=[{
-                "rgbd_cameras":2,
-                "subscribe_depth": LaunchConfiguration('depth'),
-                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
-                "subscribe_rgb": LaunchConfiguration('subscribe_rgb'),
-                "subscribe_stereo": LaunchConfiguration('stereo'),
-                "subscribe_user_data": LaunchConfiguration('subscribe_user_data'),
-                "subscribe_odom_info": ConditionalBool(True, False, IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' == 'true' or '", LaunchConfiguration('visual_odometry'), "' == 'true'"]))._predicate_func(context)).perform(context),
-                "frame_id": LaunchConfiguration('frame_id'),
-                "map_frame_id": LaunchConfiguration('map_frame_id'),
-                "odom_frame_id": LaunchConfiguration('odom_frame_id').perform(context),
-                "publish_tf": LaunchConfiguration('publish_tf_map'),
-                "initial_pose": LaunchConfiguration('initial_pose'),
-                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
-                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
-                "odom_tf_angular_variance": LaunchConfiguration('odom_tf_angular_variance'),
-                "odom_tf_linear_variance": LaunchConfiguration('odom_tf_linear_variance'),
-                "odom_sensor_sync": LaunchConfiguration('odom_sensor_sync'),
-                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
-                "database_path": LaunchConfiguration('database_path'),
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "config_path": LaunchConfiguration('cfg').perform(context),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos_image": LaunchConfiguration('qos_image'),
-                "qos_odom": LaunchConfiguration('qos_odom'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "qos_user_data": LaunchConfiguration('qos_user_data'),
-                "Mem/IncrementalMemory": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' != 'true'"]))._predicate_func(context)).perform(context),
-                "Mem/InitWMWithAllNodes": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' == 'true'"]))._predicate_func(context)).perform(context)
-            }],
-            remappings=[
-                ("rgbd_image0", '/realsense_camera1/rgbd_image'),
-                ("rgbd_image1", '/realsense_camera2/rgbd_image'),
-                ("user_data", LaunchConfiguration('user_data_topic')),
-                ("user_data_async", LaunchConfiguration('user_data_async_topic')),
-                ("odom", LaunchConfiguration('odom_topic'))],
-            arguments=[LaunchConfiguration("args")],
-            prefix=LaunchConfiguration('launch_prefix'),
-            namespace=LaunchConfiguration('namespace')),
-
-        Node(
-            package='rviz2', executable='rviz2', output='screen',
-            condition=IfCondition(LaunchConfiguration("rviz")),
-            arguments=[["-d"], [LaunchConfiguration("rviz_cfg")]]),
-        Node(
-            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb1', output='screen',
-            condition=IfCondition(LaunchConfiguration("rviz")),
-            parameters=[{
-                "decimation": 4,
-                "voxel_size": 0.0,
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
-            }],
-            remappings=[
-                ('rgb/image', LaunchConfiguration('rgb_topic1')),
-                ('depth/image', LaunchConfiguration('depth_topic1')),
-                ('rgb/camera_info', LaunchConfiguration('camera_info_topic1')),
-                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
-                ('cloud', 'voxel_cloud1')]),
-        Node(
-            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb2', output='screen',
-            condition=IfCondition(LaunchConfiguration("rviz")),
-            parameters=[{
-                "decimation": 4,
-                "voxel_size": 0.0,
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
-            }],
-            remappings=[
-                ('rgb/image', LaunchConfiguration('rgb_topic2')),
-                ('depth/image', LaunchConfiguration('depth_topic2')),
-                ('rgb/camera_info', LaunchConfiguration('camera_info_topic2')),
-                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
-                ('cloud', 'voxel_cloud2')]),    
-        ]
-
-def generate_launch_description():
-    
     config_rviz = os.path.join(
-        get_package_share_directory('rtabmap_examples'), 'launch', 'config', 'slam_D405x2_config.rviz'
+            get_package_share_directory('rtabmap_examples'), 'launch', 'config', 'slam_D405x2_config.rviz')         
+
+    rviz_node = launch_ros.actions.Node(
+        package='rviz2', executable='rviz2', output='screen',
+        arguments=[["-d"], [config_rviz]]
     )
-    
-    return LaunchDescription([
-        
-        # Arguments
-        DeclareLaunchArgument('stereo', default_value='false', description='Use stereo input instead of RGB-D.'),
 
-        DeclareLaunchArgument('localization', default_value='false', description='Launch in localization mode.'),
-        DeclareLaunchArgument('rtabmapviz',   default_value='false',  description='Launch RTAB-Map UI (optional).'),
-        DeclareLaunchArgument('rviz',         default_value='false', description='Launch RVIZ (optional).'),
+    rgbd_sync1_node = launch_ros.actions.Node(
+        package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync1', output="screen",
+        parameters=[{
+            "approx_sync": False
+            }],
+        remappings=[
+            ("rgb/image", '/camera1/color/image_rect_raw'),
+            ("depth/image", '/camera1/depth/image_rect_raw'),
+            ("rgb/camera_info", '/camera1/color/camera_info'),
+            ("rgbd_image", 'rgbd_image')],
+        namespace='realsense_camera1'
+    )
+    rgbd_sync2_node = launch_ros.actions.Node(
+        package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync2', output="screen",
+        parameters=[{
+            "approx_sync": False
+            }],
+        remappings=[
+            ("rgb/image", '/camera2/color/image_rect_raw'),
+            ("depth/image", '/camera2/depth/image_rect_raw'),
+            ("rgb/camera_info", '/camera2/color/camera_info'),
+            ("rgbd_image", 'rgbd_image')],
+        namespace='realsense_camera2'
+    )
+            
+    # RGB-D odometry
+    rgbd_odometry_node = launch_ros.actions.Node(
+        package='rtabmap_odom', executable='rgbd_odometry', output="screen",
+        parameters=[{
+            "frame_id": 'base_link',
+            "odom_frame_id": 'odom',
+            "publish_tf": True,
+            "approx_sync": True,
+            "subscribe_rgbd": True,
+            }],
+        remappings=[
+            ("rgbd_image", '/realsense_camera1/rgbd_image'),
+            ("odom", 'odom')],
+        arguments=["--delete_db_on_start", ''],
+        prefix='',
+        namespace='rtabmap'
+    )
 
-        DeclareLaunchArgument('use_sim_time', default_value='false', description='Use simulation (Gazebo) clock if true'),
+    # SLAM 
+    slam_node = launch_ros.actions.Node(
+        package='rtabmap_slam', executable='rtabmap', output="screen",
+        parameters=[{
+            "rgbd_cameras":2,
+            "subscribe_depth": True,
+            "subscribe_rgbd": True,
+            "subscribe_rgb": True,
+            "subscribe_odom_info": True,
+            "frame_id": 'base_link',
+            "map_frame_id": 'map',
+            "publish_tf": True,
+            "database_path": '~/.ros/rtabmap.db',
+            "approx_sync": True,
+            "Mem/IncrementalMemory": "true",
+            "Mem/InitWMWithAllNodes": "true"
+        }],
+        remappings=[
+            ("rgbd_image0", '/realsense_camera1/rgbd_image'),
+            ("rgbd_image1", '/realsense_camera2/rgbd_image'),
+            ("odom", 'odom')],
+        arguments=["--delete_db_on_start"],
+        prefix='',
+        namespace='rtabmap'
+    )
 
-        # Config files
-        DeclareLaunchArgument('cfg',      default_value='',                        description='To change RTAB-Map\'s parameters, set the path of config file (*.ini) generated by the standalone app.'),
-        DeclareLaunchArgument('gui_cfg',  default_value='~/.ros/rtabmap_gui.ini',  description='Configuration path of rtabmapviz.'),
-        DeclareLaunchArgument('rviz_cfg', default_value=config_rviz,               description='Configuration path of rviz2.'),
+    voxelcloud1_node = launch_ros.actions.Node(
+        package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb1', output='screen',
+        parameters=[{
+            "approx_sync": True,
+        }],
+        remappings=[
+            ('rgb/image', '/camera1/color/image_rect_raw'),
+            ('depth/image', '/camera1/depth/image_rect_raw'),
+            ('rgb/camera_info', '/camera1/color/camera_info'),
+            ('rgbd_image', 'rgbd_image'),
+            ('cloud', 'voxel_cloud1')]
+    )
 
-        DeclareLaunchArgument('frame_id',       default_value='base_link',          description='Fixed frame id of the robot (base frame), you may set "base_link" or "base_footprint" if they are published. For camera-only config, this could be "camera_link".'),
-        DeclareLaunchArgument('odom_frame_id',  default_value='',                   description='If set, TF is used to get odometry instead of the topic.'),
-        DeclareLaunchArgument('map_frame_id',   default_value='map',                description='Output map frame id (TF).'),
-        DeclareLaunchArgument('publish_tf_map', default_value='true',               description='Publish TF between map and odomerty.'),
-        DeclareLaunchArgument('namespace',      default_value='rtabmap',            description=''),
-        DeclareLaunchArgument('database_path',  default_value='~/.ros/rtabmap.db',  description='Where is the map saved/loaded.'),
-        DeclareLaunchArgument('queue_size',     default_value='10',                 description=''),
-        DeclareLaunchArgument('qos',            default_value='1',                  description='General QoS used for sensor input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('wait_for_transform', default_value='0.2',            description=''),
-        DeclareLaunchArgument('rtabmap_args',   default_value='',                   description='Backward compatibility, use "args" instead.'),
-        DeclareLaunchArgument('launch_prefix',  default_value='',                   description='For debugging purpose, it fills prefix tag of the nodes, e.g., "xterm -e gdb -ex run --args"'),
-        DeclareLaunchArgument('output',         default_value='screen',             description='Control node output (screen or log).'),
-        DeclareLaunchArgument('initial_pose',   default_value='',                   description='Set an initial pose (only in localization mode). Format: "x y z roll pitch yaw" or "x y z qx qy qz qw". Default: see "RGBD/StartAtOrigin" doc'),
-        
-        DeclareLaunchArgument('ground_truth_frame_id',      default_value='', description='e.g., "world"'),
-        DeclareLaunchArgument('ground_truth_base_frame_id', default_value='', description='e.g., "tracker", a fake frame matching the frame "frame_id" (but on different TF tree)'),
-        
-        DeclareLaunchArgument('approx_sync',  default_value='false',            description='If timestamps of the input topics should be synchronized using approximate or exact time policy.'),
-        DeclareLaunchArgument('approx_sync_max_interval',  default_value='0.0', description='(sec) 0 means infinite interval duration (used with approx_sync=true)'),
-        
-        # Use Pre-sync RGBDImage format
-        DeclareLaunchArgument('rgbd_sync',        default_value='false',      description='Pre-sync rgb_topic1, depth_topic, camera_info_topic1.'),
-        DeclareLaunchArgument('approx_rgbd_sync', default_value='true',       description='false=exact synchronization.'),
-        DeclareLaunchArgument('subscribe_rgbd',   default_value=LaunchConfiguration('rgbd_sync'), description='Already synchronized RGB-D related topic, e.g., with rtabmap_sync/rgbd_sync nodelet.'),
-        DeclareLaunchArgument('rgbd_topic',       default_value='rgbd_image', description=''),
-        DeclareLaunchArgument('depth_scale',      default_value='1.0',        description=''),
-        
-        # Image topic compression
-        DeclareLaunchArgument('compressed',            default_value='false', description='If you want to subscribe to compressed image topics'),
-        DeclareLaunchArgument('rgb_image_transport',   default_value='compressed', description='Common types: compressed, theora (see "rosrun image_transport list_transports")'),
-        DeclareLaunchArgument('depth_image_transport', default_value='compressedDepth', description='Depth compatible types: compressedDepth (see "rosrun image_transport list_transports")'),
-        
-        # Odometry
-        DeclareLaunchArgument('visual_odometry',            default_value='true',  description='Launch rtabmap visual odometry node.'),
-        DeclareLaunchArgument('icp_odometry',               default_value='false', description='Launch rtabmap icp odometry node.'),
-        DeclareLaunchArgument('odom_topic',                 default_value='odom',  description='Odometry topic name.'),
-        DeclareLaunchArgument('vo_frame_id',                default_value=LaunchConfiguration('odom_topic'), description='Visual/Icp odometry frame ID for TF.'),
-        DeclareLaunchArgument('publish_tf_odom',            default_value='true',  description=''),
-        DeclareLaunchArgument('odom_tf_angular_variance',   default_value='0.01',    description='If TF is used to get odometry, this is the default angular variance'),
-        DeclareLaunchArgument('odom_tf_linear_variance',    default_value='0.001',   description='If TF is used to get odometry, this is the default linear variance'),
-        DeclareLaunchArgument('odom_args',                  default_value='',      description='More arguments for odometry (overwrite same parameters in rtabmap_args).'),
-        DeclareLaunchArgument('odom_sensor_sync',           default_value='false', description=''),
-        DeclareLaunchArgument('odom_guess_frame_id',        default_value='',      description=''),
-        DeclareLaunchArgument('odom_guess_min_translation', default_value='0.0',   description=''),
-        DeclareLaunchArgument('odom_guess_min_rotation',    default_value='0.0',   description=''),
-        
-        # User Data
-        DeclareLaunchArgument('subscribe_user_data',   default_value='false',            description='User data synchronized subscription.'),
-        DeclareLaunchArgument('user_data_topic',       default_value='/user_data',       description=''),
-        DeclareLaunchArgument('user_data_async_topic', default_value='/user_data_async', description='User data async subscription (rate should be lower than map update rate).'),
+    voxelcloud2_node = launch_ros.actions.Node(
+        package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb2', output='screen',
+        parameters=[{
+            "approx_sync": True,
+        }],
+        remappings=[
+            ('rgb/image', '/camera2/color/image_rect_raw'),
+            ('depth/image', '/camera2/depth/image_rect_raw'),
+            ('rgb/camera_info', '/camera2/color/camera_info'),
+            ('rgbd_image', 'rgbd_image'),
+            ('cloud', 'voxel_cloud2')]
+    )    
 
-        OpaqueFunction(function=launch_setup)
-    ])
+    return launch.LaunchDescription(
+        [
+        rviz_node,
+        rgbd_sync1_node,
+        rgbd_sync2_node,
+        rgbd_odometry_node,
+        slam_node,
+        voxelcloud1_node,
+        voxelcloud2_node
+        ]
+    )

--- a/rtabmap_examples/launch/rtabmap_D405x3.launch.py
+++ b/rtabmap_examples/launch/rtabmap_D405x3.launch.py
@@ -1,6 +1,4 @@
-# Program dedicated to launch 3 realsense cameras.
-# Rtabmap, the slam components and some general default parameters are considered here for the user (they can be modifed).
-# The rtabmap.launch.py example was taken as a reference, and then two camera nodes were adapted.
+# Program dedicated to launch 3 realsense cameras. D405 were tested!
 # (Please note that this program can manage maximum 4 depth cameras)
 
 # Program modified by: Adrian Ricardez (https://github.com/adricort)
@@ -8,6 +6,8 @@
 # Deutsches Zentrum für Luft- und Raumfahrt
 
 # Requirements:
+
+# Be sure that you did the build on your rtabmap workspace with the -DRTABMAP_SYNC_MULTI_RGBD=ON parameter.
 
 # Launching the 3 realsense cameras (change your serial numbers):
 #   $ ros2 launch realsense2_camera rs_launch.py pointcloud.enable:=true serial_no:=_128422271521
@@ -18,322 +18,156 @@
 #   $ ros2 run tf2_ros static_transform_publisher --x 0 --y 0 --z 0.02 --yaw 1.5708 --pitch -1.5708 --roll 0 --frame-id base_link --child-frame-id camera1_link
 #   $ ros2 run tf2_ros static_transform_publisher --x 0 --y 0 --z -0.02 --yaw 1.5708 --pitch 1.5708 --roll 0 --frame-id base_link --child-frame-id camera2_link
 
-#   $ ros2 launch rtabmap_examples rtabmap_D405x3.launch.py rtabmap_args:="--delete_db_on_start" rgb_topic1:=/camera/color/image_rect_raw depth_topic1:=/camera/depth/image_rect_raw camera_info_topic1:=/camera/color/camera_info rgb_topic2:=/camera1/color/image_rect_raw depth_topic2:=/camera1/depth/image_rect_raw camera_info_topic2:=/camera1/color/camera_info rgb_topic3:=/camera2/color/image_rect_raw depth_topic3:=/camera2/depth/image_rect_raw camera_info_topic3:=/camera2/color/camera_info frame_id:=base_link rgbd_sync:=true subscribe_rgbd:=true approx_sync:=true rviz:=true
+#   $ ros2 launch rtabmap_examples rtabmap_D405x3.launch.py
 
-# You should be able to visualize now, with the right rviz config, the two cameras SLAM
+# You should be able to visualize now, with the right rviz config, the camera's SLAM
 # Have fun!
 
 import os
- 
-from launch import LaunchDescription, Substitution, LaunchContext
-from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable, LogInfo, OpaqueFunction
-from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir, PythonExpression
-from launch.conditions import IfCondition, UnlessCondition
-from launch_ros.actions import Node
-from launch_ros.actions import SetParameter
-from typing import Text
+import launch
+import launch_ros
 from ament_index_python.packages import get_package_share_directory
+          
+def generate_launch_description():     
 
-#Based on https://answers.ros.org/question/363763/ros2-how-best-to-conditionally-include-a-prefix-in-a-launchpy-file/
-class ConditionalText(Substitution):
-    def __init__(self, text_if, text_else, condition):
-        self.text_if = text_if
-        self.text_else = text_else
-        self.condition = condition
-
-    def perform(self, context: 'LaunchContext') -> Text:
-        if self.condition == True or self.condition == 'true' or self.condition == 'True':
-            return self.text_if
-        else:
-            return self.text_else
-            
-class ConditionalBool(Substitution):
-    def __init__(self, text_if, text_else, condition):
-        self.text_if = text_if
-        self.text_else = text_else
-        self.condition = condition
-
-    def perform(self, context: 'LaunchContext') -> bool:
-        if self.condition:
-            return self.text_if
-        else:
-            return self.text_else
-            
-def launch_setup(context, *args, **kwargs):      
-               
-    return [
-        DeclareLaunchArgument('depth', default_value=ConditionalText('false', 'true', IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' == 'true'"]))._predicate_func(context)), description=''),
-        DeclareLaunchArgument('subscribe_rgb', default_value=LaunchConfiguration('depth'), description=''),
-        DeclareLaunchArgument('args',  default_value=LaunchConfiguration('rtabmap_args'), description='Can be used to pass RTAB-Map\'s parameters or other flags like --udebug and --delete_db_on_start/-d'),
-        DeclareLaunchArgument('qos_image',       default_value=LaunchConfiguration('qos'), description='Specific QoS used for image input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('qos_camera_info', default_value=LaunchConfiguration('qos'), description='Specific QoS used for camera info input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('qos_odom',        default_value=LaunchConfiguration('qos'), description='Specific QoS used for odometry input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('qos_user_data',   default_value=LaunchConfiguration('qos'), description='Specific QoS used for user input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-    
-        SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
-        # 'use_sim_time' will be set on all nodes following the line above
-
-        Node(
-            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync1', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
-            parameters=[{
-                "approx_sync": False,
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos": LaunchConfiguration('qos_image'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "depth_scale": LaunchConfiguration('depth_scale')}],
-            remappings=[
-                ("rgb/image", LaunchConfiguration('rgb_topic1')),
-                ("depth/image", LaunchConfiguration('depth_topic1')),
-                ("rgb/camera_info", LaunchConfiguration('camera_info_topic1')),
-                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
-            namespace='realsense_camera1'),
-        Node(
-            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync2', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
-            parameters=[{
-                "approx_sync": False,
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos": LaunchConfiguration('qos_image'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "depth_scale": LaunchConfiguration('depth_scale')}],
-            remappings=[
-                ("rgb/image", LaunchConfiguration('rgb_topic2')),
-                ("depth/image", LaunchConfiguration('depth_topic2')),
-                ("rgb/camera_info", LaunchConfiguration('camera_info_topic2')),
-                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
-            namespace='realsense_camera2'),
-        Node(
-            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync3', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
-            parameters=[{
-                "approx_sync": False,
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos": LaunchConfiguration('qos_image'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "depth_scale": LaunchConfiguration('depth_scale')}],
-            remappings=[
-                ("rgb/image", LaunchConfiguration('rgb_topic3')),
-                ("depth/image", LaunchConfiguration('depth_topic3')),
-                ("rgb/camera_info", LaunchConfiguration('camera_info_topic3')),
-                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
-            namespace='realsense_camera3'),
-            
-        # Relay rgbd_image
-        Node(
-            package='rtabmap_util', executable='rgbd_relay', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' != 'true'"])),
-            remappings=[
-                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
-            namespace=LaunchConfiguration('namespace')),
-        Node(
-            package='rtabmap_util', executable='rgbd_relay', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' == 'true'"])),
-            parameters=[{
-                "uncompress": True,
-                "qos": LaunchConfiguration('qos_image')}],
-            remappings=[
-                ("rgbd_image", [LaunchConfiguration('rgbd_topic'), "/compressed"]),
-                ([LaunchConfiguration('rgbd_topic'), "/compressed_relay"], LaunchConfiguration('rgbd_topic'))],
-            namespace=LaunchConfiguration('namespace')),
-                
-        # RGB-D odometry
-        Node(
-            package='rtabmap_odom', executable='rgbd_odometry', output="screen",
-            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' != 'true' and '", LaunchConfiguration('visual_odometry'), "' == 'true' and '", LaunchConfiguration('stereo'), "' != 'true'"])),
-            parameters=[{
-                "frame_id": LaunchConfiguration('frame_id'),
-                "odom_frame_id": LaunchConfiguration('vo_frame_id'),
-                "publish_tf": LaunchConfiguration('publish_tf_odom'),
-                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
-                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
-                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
-                "config_path": LaunchConfiguration('cfg').perform(context),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos": LaunchConfiguration('qos_image'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
-                "guess_frame_id": LaunchConfiguration('odom_guess_frame_id').perform(context),
-                "guess_min_translation": LaunchConfiguration('odom_guess_min_translation'),
-                "guess_min_rotation": LaunchConfiguration('odom_guess_min_rotation')}],
-            remappings=[
-                ("rgbd_image", '/realsense_camera1/rgbd_image'),
-                ("odom", LaunchConfiguration('odom_topic'))],
-            arguments=[LaunchConfiguration("args"), LaunchConfiguration("odom_args")],
-            prefix=LaunchConfiguration('launch_prefix'),
-            namespace=LaunchConfiguration('namespace')),
-
-        Node(
-            package='rtabmap_slam', executable='rtabmap', output="screen",
-            parameters=[{
-                "rgbd_cameras":3,
-                "subscribe_depth": LaunchConfiguration('depth'),
-                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
-                "subscribe_rgb": LaunchConfiguration('subscribe_rgb'),
-                "subscribe_stereo": LaunchConfiguration('stereo'),
-                "subscribe_user_data": LaunchConfiguration('subscribe_user_data'),
-                "subscribe_odom_info": ConditionalBool(True, False, IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' == 'true' or '", LaunchConfiguration('visual_odometry'), "' == 'true'"]))._predicate_func(context)).perform(context),
-                "frame_id": LaunchConfiguration('frame_id'),
-                "map_frame_id": LaunchConfiguration('map_frame_id'),
-                "odom_frame_id": LaunchConfiguration('odom_frame_id').perform(context),
-                "publish_tf": LaunchConfiguration('publish_tf_map'),
-                "initial_pose": LaunchConfiguration('initial_pose'),
-                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
-                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
-                "odom_tf_angular_variance": LaunchConfiguration('odom_tf_angular_variance'),
-                "odom_tf_linear_variance": LaunchConfiguration('odom_tf_linear_variance'),
-                "odom_sensor_sync": LaunchConfiguration('odom_sensor_sync'),
-                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
-                "database_path": LaunchConfiguration('database_path'),
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "config_path": LaunchConfiguration('cfg').perform(context),
-                "queue_size": LaunchConfiguration('queue_size'),
-                "qos_image": LaunchConfiguration('qos_image'),
-                "qos_odom": LaunchConfiguration('qos_odom'),
-                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
-                "qos_user_data": LaunchConfiguration('qos_user_data'),
-                "Mem/IncrementalMemory": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' != 'true'"]))._predicate_func(context)).perform(context),
-                "Mem/InitWMWithAllNodes": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' == 'true'"]))._predicate_func(context)).perform(context)
-            }],
-            remappings=[
-                ("rgbd_image0", '/realsense_camera1/rgbd_image'),
-                ("rgbd_image1", '/realsense_camera2/rgbd_image'),
-                ("rgbd_image2", '/realsense_camera3/rgbd_image'),
-                ("user_data", LaunchConfiguration('user_data_topic')),
-                ("user_data_async", LaunchConfiguration('user_data_async_topic')),
-                ("odom", LaunchConfiguration('odom_topic'))],
-            arguments=[LaunchConfiguration("args")],
-            prefix=LaunchConfiguration('launch_prefix'),
-            namespace=LaunchConfiguration('namespace')),
-
-        Node(
-            package='rviz2', executable='rviz2', output='screen',
-            condition=IfCondition(LaunchConfiguration("rviz")),
-            arguments=[["-d"], [LaunchConfiguration("rviz_cfg")]]),
-        Node(
-            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb1', output='screen',
-            condition=IfCondition(LaunchConfiguration("rviz")),
-            parameters=[{
-                "decimation": 4,
-                "voxel_size": 0.0,
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
-            }],
-            remappings=[
-                ('rgb/image', LaunchConfiguration('rgb_topic1')),
-                ('depth/image', LaunchConfiguration('depth_topic1')),
-                ('rgb/camera_info', LaunchConfiguration('camera_info_topic1')),
-                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
-                ('cloud', 'voxel_cloud1')]),
-        Node(
-            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb2', output='screen',
-            condition=IfCondition(LaunchConfiguration("rviz")),
-            parameters=[{
-                "decimation": 4,
-                "voxel_size": 0.0,
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
-            }],
-            remappings=[
-                ('rgb/image', LaunchConfiguration('rgb_topic2')),
-                ('depth/image', LaunchConfiguration('depth_topic2')),
-                ('rgb/camera_info', LaunchConfiguration('camera_info_topic2')),
-                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
-                ('cloud', 'voxel_cloud2')]),
-        Node(
-            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb3', output='screen',
-            condition=IfCondition(LaunchConfiguration("rviz")),
-            parameters=[{
-                "decimation": 4,
-                "voxel_size": 0.0,
-                "approx_sync": LaunchConfiguration('approx_sync'),
-                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
-            }],
-            remappings=[
-                ('rgb/image', LaunchConfiguration('rgb_topic3')),
-                ('depth/image', LaunchConfiguration('depth_topic3')),
-                ('rgb/camera_info', LaunchConfiguration('camera_info_topic3')),
-                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
-                ('cloud', 'voxel_cloud3')]),
-        ]
-
-def generate_launch_description():
-    
     config_rviz = os.path.join(
-        get_package_share_directory('rtabmap_examples'), 'launch', 'config', 'slam_D405x3_config.rviz'
+            get_package_share_directory('rtabmap_examples'), 'launch', 'config', 'slam_D405x3_config.rviz')         
+
+    rviz_node = launch_ros.actions.Node(
+        package='rviz2', executable='rviz2', output='screen',
+        arguments=[["-d"], [config_rviz]]
     )
-    
-    return LaunchDescription([
-        
-        # Arguments
-        DeclareLaunchArgument('stereo', default_value='false', description='Use stereo input instead of RGB-D.'),
 
-        DeclareLaunchArgument('localization', default_value='false', description='Launch in localization mode.'),
-        DeclareLaunchArgument('rtabmapviz',   default_value='false',  description='Launch RTAB-Map UI (optional).'),
-        DeclareLaunchArgument('rviz',         default_value='false', description='Launch RVIZ (optional).'),
+    rgbd_sync1_node = launch_ros.actions.Node(
+        package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync1', output="screen",
+        parameters=[{
+            "approx_sync": False
+            }],
+        remappings=[
+            ("rgb/image", '/camera/color/image_rect_raw'),
+            ("depth/image", '/camera/depth/image_rect_raw'),
+            ("rgb/camera_info", '/camera/color/camera_info'),
+            ("rgbd_image", 'rgbd_image')],
+        namespace='realsense_camera1'
+    )
+    rgbd_sync2_node = launch_ros.actions.Node(
+        package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync2', output="screen",
+        parameters=[{
+            "approx_sync": False
+            }],
+        remappings=[
+            ("rgb/image", '/camera1/color/image_rect_raw'),
+            ("depth/image", '/camera1/depth/image_rect_raw'),
+            ("rgb/camera_info", '/camera1/color/camera_info'),
+            ("rgbd_image", 'rgbd_image')],
+        namespace='realsense_camera2'
+    )
+    rgbd_sync3_node = launch_ros.actions.Node(
+        package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync3', output="screen",
+        parameters=[{
+            "approx_sync": False
+            }],
+        remappings=[
+            ("rgb/image", '/camera2/color/image_rect_raw'),
+            ("depth/image", '/camera2/depth/image_rect_raw'),
+            ("rgb/camera_info", '/camera2/color/camera_info'),
+            ("rgbd_image", 'rgbd_image')],
+        namespace='realsense_camera3'
+    )
+            
+    # RGB-D odometry
+    rgbd_odometry_node = launch_ros.actions.Node(
+        package='rtabmap_odom', executable='rgbd_odometry', output="screen",
+        parameters=[{
+            "frame_id": 'base_link',
+            "odom_frame_id": 'odom',
+            "publish_tf": True,
+            "approx_sync": True,
+            "subscribe_rgbd": True,
+            }],
+        remappings=[
+            ("rgbd_image", '/realsense_camera1/rgbd_image'),
+            ("odom", 'odom')],
+        arguments=["--delete_db_on_start", ''],
+        prefix='',
+        namespace='rtabmap'
+    )
 
-        DeclareLaunchArgument('use_sim_time', default_value='false', description='Use simulation (Gazebo) clock if true'),
+    # SLAM 
+    slam_node = launch_ros.actions.Node(
+        package='rtabmap_slam', executable='rtabmap', output="screen",
+        parameters=[{
+            "rgbd_cameras":3,
+            "subscribe_depth": True,
+            "subscribe_rgbd": True,
+            "subscribe_rgb": True,
+            "subscribe_odom_info": True,
+            "frame_id": 'base_link',
+            "map_frame_id": 'map',
+            "publish_tf": True,
+            "database_path": '~/.ros/rtabmap.db',
+            "approx_sync": True,
+            "Mem/IncrementalMemory": "true",
+            "Mem/InitWMWithAllNodes": "true"
+        }],
+        remappings=[
+            ("rgbd_image0", '/realsense_camera1/rgbd_image'),
+            ("rgbd_image1", '/realsense_camera2/rgbd_image'),
+            ("rgbd_image2", '/realsense_camera3/rgbd_image'),
+            ("odom", 'odom')],
+        arguments=["--delete_db_on_start"],
+        prefix='',
+        namespace='rtabmap'
+    )
 
-        # Config files
-        DeclareLaunchArgument('cfg',      default_value='',                        description='To change RTAB-Map\'s parameters, set the path of config file (*.ini) generated by the standalone app.'),
-        DeclareLaunchArgument('gui_cfg',  default_value='~/.ros/rtabmap_gui.ini',  description='Configuration path of rtabmapviz.'),
-        DeclareLaunchArgument('rviz_cfg', default_value=config_rviz,               description='Configuration path of rviz2.'),
+    voxelcloud1_node = launch_ros.actions.Node(
+        package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb1', output='screen',
+        parameters=[{
+            "approx_sync": True,
+        }],
+        remappings=[
+            ('rgb/image', '/camera/color/image_rect_raw'),
+            ('depth/image', '/camera/depth/image_rect_raw'),
+            ('rgb/camera_info', '/camera/color/camera_info'),
+            ('rgbd_image', 'rgbd_image'),
+            ('cloud', 'voxel_cloud1')]
+    )
 
-        DeclareLaunchArgument('frame_id',       default_value='base_link',          description='Fixed frame id of the robot (base frame), you may set "base_link" or "base_footprint" if they are published. For camera-only config, this could be "camera_link".'),
-        DeclareLaunchArgument('odom_frame_id',  default_value='',                   description='If set, TF is used to get odometry instead of the topic.'),
-        DeclareLaunchArgument('map_frame_id',   default_value='map',                description='Output map frame id (TF).'),
-        DeclareLaunchArgument('publish_tf_map', default_value='true',               description='Publish TF between map and odomerty.'),
-        DeclareLaunchArgument('namespace',      default_value='rtabmap',            description=''),
-        DeclareLaunchArgument('database_path',  default_value='~/.ros/rtabmap.db',  description='Where is the map saved/loaded.'),
-        DeclareLaunchArgument('queue_size',     default_value='10',                 description=''),
-        DeclareLaunchArgument('qos',            default_value='1',                  description='General QoS used for sensor input data: 0=system default, 1=Reliable, 2=Best Effort.'),
-        DeclareLaunchArgument('wait_for_transform', default_value='0.2',            description=''),
-        DeclareLaunchArgument('rtabmap_args',   default_value='',                   description='Backward compatibility, use "args" instead.'),
-        DeclareLaunchArgument('launch_prefix',  default_value='',                   description='For debugging purpose, it fills prefix tag of the nodes, e.g., "xterm -e gdb -ex run --args"'),
-        DeclareLaunchArgument('output',         default_value='screen',             description='Control node output (screen or log).'),
-        DeclareLaunchArgument('initial_pose',   default_value='',                   description='Set an initial pose (only in localization mode). Format: "x y z roll pitch yaw" or "x y z qx qy qz qw". Default: see "RGBD/StartAtOrigin" doc'),
-        
-        DeclareLaunchArgument('ground_truth_frame_id',      default_value='', description='e.g., "world"'),
-        DeclareLaunchArgument('ground_truth_base_frame_id', default_value='', description='e.g., "tracker", a fake frame matching the frame "frame_id" (but on different TF tree)'),
-        
-        DeclareLaunchArgument('approx_sync',  default_value='false',            description='If timestamps of the input topics should be synchronized using approximate or exact time policy.'),
-        DeclareLaunchArgument('approx_sync_max_interval',  default_value='0.0', description='(sec) 0 means infinite interval duration (used with approx_sync=true)'),
-        
-        # Use Pre-sync RGBDImage format
-        DeclareLaunchArgument('rgbd_sync',        default_value='false',      description='Pre-sync rgb_topic1, depth_topic, camera_info_topic1.'),
-        DeclareLaunchArgument('approx_rgbd_sync', default_value='true',       description='false=exact synchronization.'),
-        DeclareLaunchArgument('subscribe_rgbd',   default_value=LaunchConfiguration('rgbd_sync'), description='Already synchronized RGB-D related topic, e.g., with rtabmap_sync/rgbd_sync nodelet.'),
-        DeclareLaunchArgument('rgbd_topic',       default_value='rgbd_image', description=''),
-        DeclareLaunchArgument('depth_scale',      default_value='1.0',        description=''),
-        
-        # Image topic compression
-        DeclareLaunchArgument('compressed',            default_value='false', description='If you want to subscribe to compressed image topics'),
-        DeclareLaunchArgument('rgb_image_transport',   default_value='compressed', description='Common types: compressed, theora (see "rosrun image_transport list_transports")'),
-        DeclareLaunchArgument('depth_image_transport', default_value='compressedDepth', description='Depth compatible types: compressedDepth (see "rosrun image_transport list_transports")'),
-        
-        # Odometry
-        DeclareLaunchArgument('visual_odometry',            default_value='true',  description='Launch rtabmap visual odometry node.'),
-        DeclareLaunchArgument('icp_odometry',               default_value='false', description='Launch rtabmap icp odometry node.'),
-        DeclareLaunchArgument('odom_topic',                 default_value='odom',  description='Odometry topic name.'),
-        DeclareLaunchArgument('vo_frame_id',                default_value=LaunchConfiguration('odom_topic'), description='Visual/Icp odometry frame ID for TF.'),
-        DeclareLaunchArgument('publish_tf_odom',            default_value='true',  description=''),
-        DeclareLaunchArgument('odom_tf_angular_variance',   default_value='0.01',    description='If TF is used to get odometry, this is the default angular variance'),
-        DeclareLaunchArgument('odom_tf_linear_variance',    default_value='0.001',   description='If TF is used to get odometry, this is the default linear variance'),
-        DeclareLaunchArgument('odom_args',                  default_value='',      description='More arguments for odometry (overwrite same parameters in rtabmap_args).'),
-        DeclareLaunchArgument('odom_sensor_sync',           default_value='false', description=''),
-        DeclareLaunchArgument('odom_guess_frame_id',        default_value='',      description=''),
-        DeclareLaunchArgument('odom_guess_min_translation', default_value='0.0',   description=''),
-        DeclareLaunchArgument('odom_guess_min_rotation',    default_value='0.0',   description=''),
-        
-        # User Data
-        DeclareLaunchArgument('subscribe_user_data',   default_value='false',            description='User data synchronized subscription.'),
-        DeclareLaunchArgument('user_data_topic',       default_value='/user_data',       description=''),
-        DeclareLaunchArgument('user_data_async_topic', default_value='/user_data_async', description='User data async subscription (rate should be lower than map update rate).'),
+    voxelcloud2_node = launch_ros.actions.Node(
+        package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb2', output='screen',
+        parameters=[{
+            "approx_sync": True,
+        }],
+        remappings=[
+            ('rgb/image', '/camera1/color/image_rect_raw'),
+            ('depth/image', '/camera1/depth/image_rect_raw'),
+            ('rgb/camera_info', '/camera1/color/camera_info'),
+            ('rgbd_image', 'rgbd_image'),
+            ('cloud', 'voxel_cloud2')]
+    )
+    voxelcloud3_node = launch_ros.actions.Node(
+        package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb3', output='screen',
+        parameters=[{
+            "approx_sync": True,
+        }],
+        remappings=[
+            ('rgb/image', '/camera2/color/image_rect_raw'),
+            ('depth/image', '/camera2/depth/image_rect_raw'),
+            ('rgb/camera_info', '/camera2/color/camera_info'),
+            ('rgbd_image', 'rgbd_image'),
+            ('cloud', 'voxel_cloud3')]
+    )   
 
-        OpaqueFunction(function=launch_setup)
-    ])
+    return launch.LaunchDescription(
+        [
+        rviz_node,
+        rgbd_sync1_node,
+        rgbd_sync2_node,
+        rgbd_sync3_node,
+        rgbd_odometry_node,
+        slam_node,
+        voxelcloud1_node,
+        voxelcloud2_node,
+        voxelcloud3_node,
+        ]
+    )

--- a/rtabmap_examples/launch/rtabmap_D405x3.launch.py
+++ b/rtabmap_examples/launch/rtabmap_D405x3.launch.py
@@ -1,0 +1,339 @@
+# Program dedicated to launch 3 realsense cameras.
+# Rtabmap, the slam components and some general default parameters are considered here for the user (they can be modifed).
+# The rtabmap.launch.py example was taken as a reference, and then two camera nodes were adapted.
+# (Please note that this program can manage maximum 4 depth cameras)
+
+# Program modified by: Adrian Ricardez (https://github.com/adricort)
+# Date: 07.07.2023
+# Deutsches Zentrum für Luft- und Raumfahrt
+
+# Requirements:
+
+# Launching the 3 realsense cameras (change your serial numbers):
+#   $ ros2 launch realsense2_camera rs_launch.py pointcloud.enable:=true serial_no:=_128422271521
+#   $ ros2 launch realsense2_camera rs_multi_camera_launch.py pointcloud.enable1:=true pointcloud.enable2:=true serial_no1:=_128422272518 serial_no2:=_128422272647
+
+# Running the static publishers depending on the position of your cameras:
+#   $ ros2 run tf2_ros static_transform_publisher --x 0.039 --y 0 --z 0 --yaw 0 --pitch 0 --roll 0 --frame-id base_link --child-frame-id camera_link
+#   $ ros2 run tf2_ros static_transform_publisher --x 0 --y 0 --z 0.02 --yaw 1.5708 --pitch -1.5708 --roll 0 --frame-id base_link --child-frame-id camera1_link
+#   $ ros2 run tf2_ros static_transform_publisher --x 0 --y 0 --z -0.02 --yaw 1.5708 --pitch 1.5708 --roll 0 --frame-id base_link --child-frame-id camera2_link
+
+#   $ ros2 launch rtabmap_examples rtabmap_D405x3.launch.py rtabmap_args:="--delete_db_on_start" rgb_topic1:=/camera/color/image_rect_raw depth_topic1:=/camera/depth/image_rect_raw camera_info_topic1:=/camera/color/camera_info rgb_topic2:=/camera1/color/image_rect_raw depth_topic2:=/camera1/depth/image_rect_raw camera_info_topic2:=/camera1/color/camera_info rgb_topic3:=/camera2/color/image_rect_raw depth_topic3:=/camera2/depth/image_rect_raw camera_info_topic3:=/camera2/color/camera_info frame_id:=base_link rgbd_sync:=true subscribe_rgbd:=true approx_sync:=true rviz:=true
+
+# You should be able to visualize now, with the right rviz config, the two cameras SLAM
+# Have fun!
+
+import os
+ 
+from launch import LaunchDescription, Substitution, LaunchContext
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable, LogInfo, OpaqueFunction
+from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir, PythonExpression
+from launch.conditions import IfCondition, UnlessCondition
+from launch_ros.actions import Node
+from launch_ros.actions import SetParameter
+from typing import Text
+from ament_index_python.packages import get_package_share_directory
+
+#Based on https://answers.ros.org/question/363763/ros2-how-best-to-conditionally-include-a-prefix-in-a-launchpy-file/
+class ConditionalText(Substitution):
+    def __init__(self, text_if, text_else, condition):
+        self.text_if = text_if
+        self.text_else = text_else
+        self.condition = condition
+
+    def perform(self, context: 'LaunchContext') -> Text:
+        if self.condition == True or self.condition == 'true' or self.condition == 'True':
+            return self.text_if
+        else:
+            return self.text_else
+            
+class ConditionalBool(Substitution):
+    def __init__(self, text_if, text_else, condition):
+        self.text_if = text_if
+        self.text_else = text_else
+        self.condition = condition
+
+    def perform(self, context: 'LaunchContext') -> bool:
+        if self.condition:
+            return self.text_if
+        else:
+            return self.text_else
+            
+def launch_setup(context, *args, **kwargs):      
+               
+    return [
+        DeclareLaunchArgument('depth', default_value=ConditionalText('false', 'true', IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' == 'true'"]))._predicate_func(context)), description=''),
+        DeclareLaunchArgument('subscribe_rgb', default_value=LaunchConfiguration('depth'), description=''),
+        DeclareLaunchArgument('args',  default_value=LaunchConfiguration('rtabmap_args'), description='Can be used to pass RTAB-Map\'s parameters or other flags like --udebug and --delete_db_on_start/-d'),
+        DeclareLaunchArgument('qos_image',       default_value=LaunchConfiguration('qos'), description='Specific QoS used for image input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('qos_camera_info', default_value=LaunchConfiguration('qos'), description='Specific QoS used for camera info input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('qos_odom',        default_value=LaunchConfiguration('qos'), description='Specific QoS used for odometry input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('qos_user_data',   default_value=LaunchConfiguration('qos'), description='Specific QoS used for user input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+    
+        SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
+        # 'use_sim_time' will be set on all nodes following the line above
+
+        Node(
+            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync1', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
+            parameters=[{
+                "approx_sync": False,
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos": LaunchConfiguration('qos_image'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "depth_scale": LaunchConfiguration('depth_scale')}],
+            remappings=[
+                ("rgb/image", LaunchConfiguration('rgb_topic1')),
+                ("depth/image", LaunchConfiguration('depth_topic1')),
+                ("rgb/camera_info", LaunchConfiguration('camera_info_topic1')),
+                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
+            namespace='realsense_camera1'),
+        Node(
+            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync2', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
+            parameters=[{
+                "approx_sync": False,
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos": LaunchConfiguration('qos_image'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "depth_scale": LaunchConfiguration('depth_scale')}],
+            remappings=[
+                ("rgb/image", LaunchConfiguration('rgb_topic2')),
+                ("depth/image", LaunchConfiguration('depth_topic2')),
+                ("rgb/camera_info", LaunchConfiguration('camera_info_topic2')),
+                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
+            namespace='realsense_camera2'),
+        Node(
+            package='rtabmap_sync', executable='rgbd_sync', name='rgbd_sync3', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' != 'true' and '", LaunchConfiguration('rgbd_sync'), "' == 'true'"])),
+            parameters=[{
+                "approx_sync": False,
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos": LaunchConfiguration('qos_image'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "depth_scale": LaunchConfiguration('depth_scale')}],
+            remappings=[
+                ("rgb/image", LaunchConfiguration('rgb_topic3')),
+                ("depth/image", LaunchConfiguration('depth_topic3')),
+                ("rgb/camera_info", LaunchConfiguration('camera_info_topic3')),
+                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
+            namespace='realsense_camera3'),
+            
+        # Relay rgbd_image
+        Node(
+            package='rtabmap_util', executable='rgbd_relay', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' != 'true'"])),
+            remappings=[
+                ("rgbd_image", LaunchConfiguration('rgbd_topic'))],
+            namespace=LaunchConfiguration('namespace')),
+        Node(
+            package='rtabmap_util', executable='rgbd_relay', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('rgbd_sync'), "' != 'true' and '", LaunchConfiguration('subscribe_rgbd'), "' == 'true' and '", LaunchConfiguration('compressed'), "' == 'true'"])),
+            parameters=[{
+                "uncompress": True,
+                "qos": LaunchConfiguration('qos_image')}],
+            remappings=[
+                ("rgbd_image", [LaunchConfiguration('rgbd_topic'), "/compressed"]),
+                ([LaunchConfiguration('rgbd_topic'), "/compressed_relay"], LaunchConfiguration('rgbd_topic'))],
+            namespace=LaunchConfiguration('namespace')),
+                
+        # RGB-D odometry
+        Node(
+            package='rtabmap_odom', executable='rgbd_odometry', output="screen",
+            condition=IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' != 'true' and '", LaunchConfiguration('visual_odometry'), "' == 'true' and '", LaunchConfiguration('stereo'), "' != 'true'"])),
+            parameters=[{
+                "frame_id": LaunchConfiguration('frame_id'),
+                "odom_frame_id": LaunchConfiguration('vo_frame_id'),
+                "publish_tf": LaunchConfiguration('publish_tf_odom'),
+                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
+                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
+                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval'),
+                "config_path": LaunchConfiguration('cfg').perform(context),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos": LaunchConfiguration('qos_image'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
+                "guess_frame_id": LaunchConfiguration('odom_guess_frame_id').perform(context),
+                "guess_min_translation": LaunchConfiguration('odom_guess_min_translation'),
+                "guess_min_rotation": LaunchConfiguration('odom_guess_min_rotation')}],
+            remappings=[
+                ("rgbd_image", '/realsense_camera1/rgbd_image'),
+                ("odom", LaunchConfiguration('odom_topic'))],
+            arguments=[LaunchConfiguration("args"), LaunchConfiguration("odom_args")],
+            prefix=LaunchConfiguration('launch_prefix'),
+            namespace=LaunchConfiguration('namespace')),
+
+        Node(
+            package='rtabmap_slam', executable='rtabmap', output="screen",
+            parameters=[{
+                "rgbd_cameras":3,
+                "subscribe_depth": LaunchConfiguration('depth'),
+                "subscribe_rgbd": LaunchConfiguration('subscribe_rgbd'),
+                "subscribe_rgb": LaunchConfiguration('subscribe_rgb'),
+                "subscribe_stereo": LaunchConfiguration('stereo'),
+                "subscribe_user_data": LaunchConfiguration('subscribe_user_data'),
+                "subscribe_odom_info": ConditionalBool(True, False, IfCondition(PythonExpression(["'", LaunchConfiguration('icp_odometry'), "' == 'true' or '", LaunchConfiguration('visual_odometry'), "' == 'true'"]))._predicate_func(context)).perform(context),
+                "frame_id": LaunchConfiguration('frame_id'),
+                "map_frame_id": LaunchConfiguration('map_frame_id'),
+                "odom_frame_id": LaunchConfiguration('odom_frame_id').perform(context),
+                "publish_tf": LaunchConfiguration('publish_tf_map'),
+                "initial_pose": LaunchConfiguration('initial_pose'),
+                "ground_truth_frame_id": LaunchConfiguration('ground_truth_frame_id').perform(context),
+                "ground_truth_base_frame_id": LaunchConfiguration('ground_truth_base_frame_id').perform(context),
+                "odom_tf_angular_variance": LaunchConfiguration('odom_tf_angular_variance'),
+                "odom_tf_linear_variance": LaunchConfiguration('odom_tf_linear_variance'),
+                "odom_sensor_sync": LaunchConfiguration('odom_sensor_sync'),
+                "wait_for_transform": LaunchConfiguration('wait_for_transform'),
+                "database_path": LaunchConfiguration('database_path'),
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "config_path": LaunchConfiguration('cfg').perform(context),
+                "queue_size": LaunchConfiguration('queue_size'),
+                "qos_image": LaunchConfiguration('qos_image'),
+                "qos_odom": LaunchConfiguration('qos_odom'),
+                "qos_camera_info": LaunchConfiguration('qos_camera_info'),
+                "qos_user_data": LaunchConfiguration('qos_user_data'),
+                "Mem/IncrementalMemory": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' != 'true'"]))._predicate_func(context)).perform(context),
+                "Mem/InitWMWithAllNodes": ConditionalText("true", "false", IfCondition(PythonExpression(["'", LaunchConfiguration('localization'), "' == 'true'"]))._predicate_func(context)).perform(context)
+            }],
+            remappings=[
+                ("rgbd_image0", '/realsense_camera1/rgbd_image'),
+                ("rgbd_image1", '/realsense_camera2/rgbd_image'),
+                ("rgbd_image2", '/realsense_camera3/rgbd_image'),
+                ("user_data", LaunchConfiguration('user_data_topic')),
+                ("user_data_async", LaunchConfiguration('user_data_async_topic')),
+                ("odom", LaunchConfiguration('odom_topic'))],
+            arguments=[LaunchConfiguration("args")],
+            prefix=LaunchConfiguration('launch_prefix'),
+            namespace=LaunchConfiguration('namespace')),
+
+        Node(
+            package='rviz2', executable='rviz2', output='screen',
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            arguments=[["-d"], [LaunchConfiguration("rviz_cfg")]]),
+        Node(
+            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb1', output='screen',
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            parameters=[{
+                "decimation": 4,
+                "voxel_size": 0.0,
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
+            }],
+            remappings=[
+                ('rgb/image', LaunchConfiguration('rgb_topic1')),
+                ('depth/image', LaunchConfiguration('depth_topic1')),
+                ('rgb/camera_info', LaunchConfiguration('camera_info_topic1')),
+                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
+                ('cloud', 'voxel_cloud1')]),
+        Node(
+            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb2', output='screen',
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            parameters=[{
+                "decimation": 4,
+                "voxel_size": 0.0,
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
+            }],
+            remappings=[
+                ('rgb/image', LaunchConfiguration('rgb_topic2')),
+                ('depth/image', LaunchConfiguration('depth_topic2')),
+                ('rgb/camera_info', LaunchConfiguration('camera_info_topic2')),
+                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
+                ('cloud', 'voxel_cloud2')]),
+        Node(
+            package='rtabmap_util', executable='point_cloud_xyzrgb', name='point_cloud_xyzrgb3', output='screen',
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            parameters=[{
+                "decimation": 4,
+                "voxel_size": 0.0,
+                "approx_sync": LaunchConfiguration('approx_sync'),
+                "approx_sync_max_interval": LaunchConfiguration('approx_sync_max_interval')
+            }],
+            remappings=[
+                ('rgb/image', LaunchConfiguration('rgb_topic3')),
+                ('depth/image', LaunchConfiguration('depth_topic3')),
+                ('rgb/camera_info', LaunchConfiguration('camera_info_topic3')),
+                ('rgbd_image', LaunchConfiguration('rgbd_topic')),
+                ('cloud', 'voxel_cloud3')]),
+        ]
+
+def generate_launch_description():
+    
+    config_rviz = os.path.join(
+        get_package_share_directory('rtabmap_examples'), 'launch', 'config', 'slam_D405x3_config.rviz'
+    )
+    
+    return LaunchDescription([
+        
+        # Arguments
+        DeclareLaunchArgument('stereo', default_value='false', description='Use stereo input instead of RGB-D.'),
+
+        DeclareLaunchArgument('localization', default_value='false', description='Launch in localization mode.'),
+        DeclareLaunchArgument('rtabmapviz',   default_value='false',  description='Launch RTAB-Map UI (optional).'),
+        DeclareLaunchArgument('rviz',         default_value='false', description='Launch RVIZ (optional).'),
+
+        DeclareLaunchArgument('use_sim_time', default_value='false', description='Use simulation (Gazebo) clock if true'),
+
+        # Config files
+        DeclareLaunchArgument('cfg',      default_value='',                        description='To change RTAB-Map\'s parameters, set the path of config file (*.ini) generated by the standalone app.'),
+        DeclareLaunchArgument('gui_cfg',  default_value='~/.ros/rtabmap_gui.ini',  description='Configuration path of rtabmapviz.'),
+        DeclareLaunchArgument('rviz_cfg', default_value=config_rviz,               description='Configuration path of rviz2.'),
+
+        DeclareLaunchArgument('frame_id',       default_value='base_link',          description='Fixed frame id of the robot (base frame), you may set "base_link" or "base_footprint" if they are published. For camera-only config, this could be "camera_link".'),
+        DeclareLaunchArgument('odom_frame_id',  default_value='',                   description='If set, TF is used to get odometry instead of the topic.'),
+        DeclareLaunchArgument('map_frame_id',   default_value='map',                description='Output map frame id (TF).'),
+        DeclareLaunchArgument('publish_tf_map', default_value='true',               description='Publish TF between map and odomerty.'),
+        DeclareLaunchArgument('namespace',      default_value='rtabmap',            description=''),
+        DeclareLaunchArgument('database_path',  default_value='~/.ros/rtabmap.db',  description='Where is the map saved/loaded.'),
+        DeclareLaunchArgument('queue_size',     default_value='10',                 description=''),
+        DeclareLaunchArgument('qos',            default_value='1',                  description='General QoS used for sensor input data: 0=system default, 1=Reliable, 2=Best Effort.'),
+        DeclareLaunchArgument('wait_for_transform', default_value='0.2',            description=''),
+        DeclareLaunchArgument('rtabmap_args',   default_value='',                   description='Backward compatibility, use "args" instead.'),
+        DeclareLaunchArgument('launch_prefix',  default_value='',                   description='For debugging purpose, it fills prefix tag of the nodes, e.g., "xterm -e gdb -ex run --args"'),
+        DeclareLaunchArgument('output',         default_value='screen',             description='Control node output (screen or log).'),
+        DeclareLaunchArgument('initial_pose',   default_value='',                   description='Set an initial pose (only in localization mode). Format: "x y z roll pitch yaw" or "x y z qx qy qz qw". Default: see "RGBD/StartAtOrigin" doc'),
+        
+        DeclareLaunchArgument('ground_truth_frame_id',      default_value='', description='e.g., "world"'),
+        DeclareLaunchArgument('ground_truth_base_frame_id', default_value='', description='e.g., "tracker", a fake frame matching the frame "frame_id" (but on different TF tree)'),
+        
+        DeclareLaunchArgument('approx_sync',  default_value='false',            description='If timestamps of the input topics should be synchronized using approximate or exact time policy.'),
+        DeclareLaunchArgument('approx_sync_max_interval',  default_value='0.0', description='(sec) 0 means infinite interval duration (used with approx_sync=true)'),
+        
+        # Use Pre-sync RGBDImage format
+        DeclareLaunchArgument('rgbd_sync',        default_value='false',      description='Pre-sync rgb_topic1, depth_topic, camera_info_topic1.'),
+        DeclareLaunchArgument('approx_rgbd_sync', default_value='true',       description='false=exact synchronization.'),
+        DeclareLaunchArgument('subscribe_rgbd',   default_value=LaunchConfiguration('rgbd_sync'), description='Already synchronized RGB-D related topic, e.g., with rtabmap_sync/rgbd_sync nodelet.'),
+        DeclareLaunchArgument('rgbd_topic',       default_value='rgbd_image', description=''),
+        DeclareLaunchArgument('depth_scale',      default_value='1.0',        description=''),
+        
+        # Image topic compression
+        DeclareLaunchArgument('compressed',            default_value='false', description='If you want to subscribe to compressed image topics'),
+        DeclareLaunchArgument('rgb_image_transport',   default_value='compressed', description='Common types: compressed, theora (see "rosrun image_transport list_transports")'),
+        DeclareLaunchArgument('depth_image_transport', default_value='compressedDepth', description='Depth compatible types: compressedDepth (see "rosrun image_transport list_transports")'),
+        
+        # Odometry
+        DeclareLaunchArgument('visual_odometry',            default_value='true',  description='Launch rtabmap visual odometry node.'),
+        DeclareLaunchArgument('icp_odometry',               default_value='false', description='Launch rtabmap icp odometry node.'),
+        DeclareLaunchArgument('odom_topic',                 default_value='odom',  description='Odometry topic name.'),
+        DeclareLaunchArgument('vo_frame_id',                default_value=LaunchConfiguration('odom_topic'), description='Visual/Icp odometry frame ID for TF.'),
+        DeclareLaunchArgument('publish_tf_odom',            default_value='true',  description=''),
+        DeclareLaunchArgument('odom_tf_angular_variance',   default_value='0.01',    description='If TF is used to get odometry, this is the default angular variance'),
+        DeclareLaunchArgument('odom_tf_linear_variance',    default_value='0.001',   description='If TF is used to get odometry, this is the default linear variance'),
+        DeclareLaunchArgument('odom_args',                  default_value='',      description='More arguments for odometry (overwrite same parameters in rtabmap_args).'),
+        DeclareLaunchArgument('odom_sensor_sync',           default_value='false', description=''),
+        DeclareLaunchArgument('odom_guess_frame_id',        default_value='',      description=''),
+        DeclareLaunchArgument('odom_guess_min_translation', default_value='0.0',   description=''),
+        DeclareLaunchArgument('odom_guess_min_rotation',    default_value='0.0',   description=''),
+        
+        # User Data
+        DeclareLaunchArgument('subscribe_user_data',   default_value='false',            description='User data synchronized subscription.'),
+        DeclareLaunchArgument('user_data_topic',       default_value='/user_data',       description=''),
+        DeclareLaunchArgument('user_data_async_topic', default_value='/user_data_async', description='User data async subscription (rate should be lower than map update rate).'),
+
+        OpaqueFunction(function=launch_setup)
+    ])


### PR DESCRIPTION
Since there are not well documented examples in ROS2 for multi cameras, I configured two launch codes with their respective easy-to-use rviz config files, which mainly are two examples with:
- 2 Intel RealSense D405 cameras
- 3 Intel RealSense D405 cameras
In can manage up to 4, but I only tested it with 3.
It took me some time and an open issue (it will be closed soon) in the forum to get it working in the real robotic arm that I am working on. This will help people to transfer quickly their projects.

I am using: multi cameras to create a single rgbd_image, which will help to create a synchronous MapCloud, and, so far, it is only using the odometry of the front camera.

Thanks to the team for the help, I hope the pull request can be accepted.