### PR TITLE
Fix format security error in rgbdx_sync.cpp

### DIFF
--- a/rtabmap_sync/src/nodelets/rgbdx_sync.cpp
+++ b/rtabmap_sync/src/nodelets/rgbdx_sync.cpp
@@ -164,7 +164,7 @@ private:
 
 		std::string subscribedTopicsMsg = uFormat("%s%s", subscribedTopicsMsg_.c_str(),
 				approxSync&&approxSyncMaxInterval!=0.0?uFormat(" (approx sync max interval=%fs)", approxSyncMaxInterval).c_str():"");
-		NODELET_INFO(subscribedTopicsMsg.c_str());
+		NODELET_INFO("%s", subscribedTopicsMsg.c_str());
 
 		// Setup diagnostic
 		syncDiagnostic_.reset(new SyncDiagnostic(nh, pnh, getName()));


### PR DESCRIPTION
This fixes a regression in Noetic. All the `rtabmap_ros` binary jobs in Noetic are failing with the following error:

```
18:59:28 /opt/ros/noetic/include/ros/console.h:351:176: error: format not a string literal and no format arguments [-Werror=format-security]
...
18:59:28 /tmp/binarydeb/ros-noetic-rtabmap-sync-0.21.3/src/nodelets/rgbdx_sync.cpp:167:3: note: in expansion of macro ‘NODELET_INFO’
18:59:28   167 |   NODELET_INFO(subscribedTopicsMsg.c_str());
18:59:28       |   ^~~~~~~~~~~~
```

https://build.ros.org/job/Nbin_uF64__rtabmap_sync__ubuntu_focal_amd64__binary/6

Note I edited this in the github UI. I haven't built this locally.