### PR TITLE
update realsense examples for ros2

### DIFF
--- a/rtabmap_examples/launch/realsense_d435i_color.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_color.launch.py
@@ -2,7 +2,7 @@
 #   A realsense D435i
 #   Install realsense2 ros2 package (ros-$ROS_DISTRO-realsense2-camera)
 # Example:
-#   $ ros2 launch realsense2_camera rs_launch.py enable_gyro:=true enable_accel:=true unite_imu_method:=1 enable_sync:=true
+#   $ ros2 launch realsense2_camera rs_launch.py enable_gyro:=true enable_accel:=true unite_imu_method:=1 enable_sync:=true align_depth.enable:=true
 #
 #   $ ros2 launch rtabmap_examples realsense_d435i_color.launch.py
 
@@ -25,9 +25,9 @@ def generate_launch_description():
 
     remappings=[
           ('imu', '/imu/data'),
-          ('rgb/image', '/camera/color/image_raw'),
-          ('rgb/camera_info', '/camera/color/camera_info'),
-          ('depth/image', '/camera/aligned_depth_to_color/image_raw')]
+          ('rgb/image', '/camera/camera/color/image_raw'),
+          ('rgb/camera_info', '/camera/camera/color/camera_info'),
+          ('depth/image', '/camera/camera/aligned_depth_to_color/image_raw')]
 
     return LaunchDescription([
 
@@ -41,7 +41,7 @@ def generate_launch_description():
                 '/rs_launch.py']),
                 launch_arguments={'enable_gyro': 'true',
                                   'enable_accel': 'true',
-                                  'unite_imu_method': '1',
+                                  'unite_imu_method': '2',
                                   'align_depth.enable': 'true',
                                   'enable_sync': 'true',
                                   'rgb_camera.profile': '640x360x30'}.items(),
@@ -69,7 +69,7 @@ def generate_launch_description():
             parameters=[{'use_mag': False, 
                          'world_frame':'enu', 
                          'publish_tf':False}],
-            remappings=[('imu/data_raw', '/camera/imu')]),
+            remappings=[('imu/data_raw', '/camera/camera/imu')]),
         
         # The IMU frame is missing in TF tree, add it:
         Node(

--- a/rtabmap_examples/launch/realsense_d435i_color.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_color.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('realsense2_camera'), 'launch'),
                 '/rs_launch.py']),
-                launch_arguments={'camera_namespace': "",
+                launch_arguments={'camera_namespace': '',
                                   'enable_gyro': 'true',
                                   'enable_accel': 'true',
                                   'unite_imu_method': '2',

--- a/rtabmap_examples/launch/realsense_d435i_color.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_color.launch.py
@@ -2,8 +2,6 @@
 #   A realsense D435i
 #   Install realsense2 ros2 package (ros-$ROS_DISTRO-realsense2-camera)
 # Example:
-#   $ ros2 launch realsense2_camera rs_launch.py enable_gyro:=true enable_accel:=true unite_imu_method:=1 enable_sync:=true align_depth.enable:=true
-#
 #   $ ros2 launch rtabmap_examples realsense_d435i_color.launch.py
 
 import os
@@ -25,9 +23,9 @@ def generate_launch_description():
 
     remappings=[
           ('imu', '/imu/data'),
-          ('rgb/image', '/camera/camera/color/image_raw'),
-          ('rgb/camera_info', '/camera/camera/color/camera_info'),
-          ('depth/image', '/camera/camera/aligned_depth_to_color/image_raw')]
+          ('rgb/image', '/camera/color/image_raw'),
+          ('rgb/camera_info', '/camera/color/camera_info'),
+          ('depth/image', '/camera/aligned_depth_to_color/image_raw')]
 
     return LaunchDescription([
 
@@ -39,7 +37,8 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('realsense2_camera'), 'launch'),
                 '/rs_launch.py']),
-                launch_arguments={'enable_gyro': 'true',
+                launch_arguments={'camera_namespace': "",
+                                  'enable_gyro': 'true',
                                   'enable_accel': 'true',
                                   'unite_imu_method': '2',
                                   'align_depth.enable': 'true',
@@ -69,7 +68,7 @@ def generate_launch_description():
             parameters=[{'use_mag': False, 
                          'world_frame':'enu', 
                          'publish_tf':False}],
-            remappings=[('imu/data_raw', '/camera/camera/imu')]),
+            remappings=[('imu/data_raw', '/camera/imu')]),
         
         # The IMU frame is missing in TF tree, add it:
         Node(

--- a/rtabmap_examples/launch/realsense_d435i_infra.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_infra.launch.py
@@ -23,9 +23,9 @@ def generate_launch_description():
 
     remappings=[
           ('imu', '/imu/data'),
-          ('rgb/image', '/camera/infra1/image_rect_raw'),
-          ('rgb/camera_info', '/camera/infra1/camera_info'),
-          ('depth/image', '/camera/depth/image_rect_raw')]
+          ('rgb/image', '/camera/camera/infra1/image_rect_raw'),
+          ('rgb/camera_info', '/camera/camera/infra1/camera_info'),
+          ('depth/image', '/camera/camera/depth/image_rect_raw')]
 
     return LaunchDescription([
 
@@ -39,7 +39,7 @@ def generate_launch_description():
                 '/rs_launch.py']),
                 launch_arguments={'enable_gyro': 'true',
                                   'enable_accel': 'true',
-                                  'unite_imu_method': '1',
+                                  'unite_imu_method': '2',
                                   'enable_infra1': 'true',
                                   'enable_infra2': 'true',
                                   'enable_sync': 'true'}.items(),
@@ -67,7 +67,7 @@ def generate_launch_description():
             parameters=[{'use_mag': False, 
                          'world_frame':'enu', 
                          'publish_tf':False}],
-            remappings=[('imu/data_raw', '/camera/imu')]),
+            remappings=[('imu/data_raw', '/camera/camera/imu')]),
         
         # The IMU frame is missing in TF tree, add it:
         Node(

--- a/rtabmap_examples/launch/realsense_d435i_infra.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_infra.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('realsense2_camera'), 'launch'),
                 '/rs_launch.py']),
-                launch_arguments={'camera_namespace': "",
+                launch_arguments={'camera_namespace': '',
                                   'enable_gyro': 'true',
                                   'enable_accel': 'true',
                                   'unite_imu_method': '2',

--- a/rtabmap_examples/launch/realsense_d435i_infra.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_infra.launch.py
@@ -23,9 +23,9 @@ def generate_launch_description():
 
     remappings=[
           ('imu', '/imu/data'),
-          ('rgb/image', '/camera/camera/infra1/image_rect_raw'),
-          ('rgb/camera_info', '/camera/camera/infra1/camera_info'),
-          ('depth/image', '/camera/camera/depth/image_rect_raw')]
+          ('rgb/image', '/camera/infra1/image_rect_raw'),
+          ('rgb/camera_info', '/camera/infra1/camera_info'),
+          ('depth/image', '/camera/depth/image_rect_raw')]
 
     return LaunchDescription([
 
@@ -37,7 +37,8 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('realsense2_camera'), 'launch'),
                 '/rs_launch.py']),
-                launch_arguments={'enable_gyro': 'true',
+                launch_arguments={'camera_namespace': "",
+                                  'enable_gyro': 'true',
                                   'enable_accel': 'true',
                                   'unite_imu_method': '2',
                                   'enable_infra1': 'true',
@@ -67,7 +68,7 @@ def generate_launch_description():
             parameters=[{'use_mag': False, 
                          'world_frame':'enu', 
                          'publish_tf':False}],
-            remappings=[('imu/data_raw', '/camera/camera/imu')]),
+            remappings=[('imu/data_raw', '/camera/imu')]),
         
         # The IMU frame is missing in TF tree, add it:
         Node(

--- a/rtabmap_examples/launch/realsense_d435i_stereo.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_stereo.launch.py
@@ -22,10 +22,10 @@ def generate_launch_description():
 
     remappings=[
           ('imu', '/imu/data'),
-          ('left/image_rect', '/camera/camera/infra1/image_rect_raw'),
-          ('left/camera_info', '/camera/camera/infra1/camera_info'),
-          ('right/image_rect', '/camera/camera/infra2/image_rect_raw'),
-          ('right/camera_info', '/camera/camera/infra2/camera_info')]
+          ('left/image_rect', '/camera/infra1/image_rect_raw'),
+          ('left/camera_info', '/camera/infra1/camera_info'),
+          ('right/image_rect', '/camera/infra2/image_rect_raw'),
+          ('right/camera_info', '/camera/infra2/camera_info')]
 
     return LaunchDescription([
 
@@ -37,7 +37,8 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('realsense2_camera'), 'launch'),
                 '/rs_launch.py']),
-                launch_arguments={'enable_gyro': 'true',
+                launch_arguments={'camera_namespace': "",
+                                  'enable_gyro': 'true',
                                   'enable_accel': 'true',
                                   'unite_imu_method': '2',
                                   'enable_infra1': 'true',
@@ -67,7 +68,7 @@ def generate_launch_description():
             parameters=[{'use_mag': False, 
                          'world_frame':'enu', 
                          'publish_tf':False}],
-            remappings=[('imu/data_raw', '/camera/camera/imu')]),
+            remappings=[('imu/data_raw', '/camera/imu')]),
         
         # The IMU frame is missing in TF tree, add it:
         Node(

--- a/rtabmap_examples/launch/realsense_d435i_stereo.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_stereo.launch.py
@@ -22,10 +22,10 @@ def generate_launch_description():
 
     remappings=[
           ('imu', '/imu/data'),
-          ('left/image_rect', '/camera/infra1/image_rect_raw'),
-          ('left/camera_info', '/camera/infra1/camera_info'),
-          ('right/image_rect', '/camera/infra2/image_rect_raw'),
-          ('right/camera_info', '/camera/infra2/camera_info')]
+          ('left/image_rect', '/camera/camera/infra1/image_rect_raw'),
+          ('left/camera_info', '/camera/camera/infra1/camera_info'),
+          ('right/image_rect', '/camera/camera/infra2/image_rect_raw'),
+          ('right/camera_info', '/camera/camera/infra2/camera_info')]
 
     return LaunchDescription([
 
@@ -39,7 +39,7 @@ def generate_launch_description():
                 '/rs_launch.py']),
                 launch_arguments={'enable_gyro': 'true',
                                   'enable_accel': 'true',
-                                  'unite_imu_method': '1',
+                                  'unite_imu_method': '2',
                                   'enable_infra1': 'true',
                                   'enable_infra2': 'true',
                                   'enable_sync': 'true'}.items(),
@@ -67,7 +67,7 @@ def generate_launch_description():
             parameters=[{'use_mag': False, 
                          'world_frame':'enu', 
                          'publish_tf':False}],
-            remappings=[('imu/data_raw', '/camera/imu')]),
+            remappings=[('imu/data_raw', '/camera/camera/imu')]),
         
         # The IMU frame is missing in TF tree, add it:
         Node(

--- a/rtabmap_examples/launch/realsense_d435i_stereo.launch.py
+++ b/rtabmap_examples/launch/realsense_d435i_stereo.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([os.path.join(
                 get_package_share_directory('realsense2_camera'), 'launch'),
                 '/rs_launch.py']),
-                launch_arguments={'camera_namespace': "",
+                launch_arguments={'camera_namespace': '',
                                   'enable_gyro': 'true',
                                   'enable_accel': 'true',
                                   'unite_imu_method': '2',


### PR DESCRIPTION
Not sure which realsense-ros version made these namespace changes, but the examples don't work anymore.

resolves [this](https://github.com/introlab/rtabmap_ros/issues/1221#issuecomment-2417042149).

Could we port these back to the older distros as well please?