### PR TITLE
Fixed callbackCloud warning

### DIFF
--- a/rtabmap_util/src/nodelets/point_cloud_assembler.cpp
+++ b/rtabmap_util/src/nodelets/point_cloud_assembler.cpp
@@ -174,13 +174,16 @@ PointCloudAssembler::PointCloudAssembler(const rclcpp::NodeOptions & options) :
 		rclcpp::Rate r(1.0/5.0);
 		while(!callbackCalled_)
 		{
-			RCLCPP_WARN(this->get_logger(),
-					"%s: Did not receive data since 5 seconds! Make sure the input topics are "
-					"published (\"$ ros2 topic hz my_topic\") and the timestamps in their "
-					"header are set. %s",
-					get_name(),
-					subscribedTopicsMsg_.c_str());
 			r.sleep();
+			if(!callbackCalled_)
+			{
+				RCLCPP_WARN(this->get_logger(),
+						"%s: Did not receive data since 5 seconds! Make sure the input topics are "
+						"published (\"$ ros2 topic hz my_topic\") and the timestamps in their "
+						"header are set. %s",
+						get_name(),
+						subscribedTopicsMsg_.c_str());
+			}
 		}
 	});
 

--- a/rtabmap_util/src/nodelets/point_cloud_assembler.cpp
+++ b/rtabmap_util/src/nodelets/point_cloud_assembler.cpp
@@ -174,16 +174,13 @@ PointCloudAssembler::PointCloudAssembler(const rclcpp::NodeOptions & options) :
 		rclcpp::Rate r(1.0/5.0);
 		while(!callbackCalled_)
 		{
+			RCLCPP_WARN(this->get_logger(),
+					"%s: Did not receive data since 5 seconds! Make sure the input topics are "
+					"published (\"$ ros2 topic hz my_topic\") and the timestamps in their "
+					"header are set. %s",
+					get_name(),
+					subscribedTopicsMsg_.c_str());
 			r.sleep();
-			if(!callbackCalled_)
-			{
-				RCLCPP_WARN(this->get_logger(),
-						"%s: Did not receive data since 5 seconds! Make sure the input topics are "
-						"published (\"$ ros2 topic hz my_topic\") and the timestamps in their "
-						"header are set. %s",
-						get_name(),
-						subscribedTopicsMsg_.c_str());
-			}
 		}
 	});
 
@@ -286,13 +283,14 @@ void PointCloudAssembler::callbackCloudOdomInfo(
 	}
 	else
 	{
-		RCLCPP_WARN(this->get_logger(), "Reseting point cloud assembler as null odometry has been received.");
+		RCLCPP_WARN(this->get_logger(), "Resetting point cloud assembler as null odometry has been received.");
 		clouds_.clear();
 	}
 }
 
 void PointCloudAssembler::callbackCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr cloudMsg)
 {
+	callbackCalled_ = true;
 	if(cloudPub_->get_subscription_count())
 	{
 		UASSERT_MSG(cloudMsg->data.size() == cloudMsg->row_step*cloudMsg->height,


### PR DESCRIPTION
Bonjour de Sherbrooke Mathieu,

Since calbackCloud() is the only callback when called while using tf instead of odom in this node, the callbackCalled_ variable is never set to true, so the warning keeps spinning. Therefore, I added the variable to calbackCloud()  and removed a useless condition within the warning loop.

Please let me know if the fixes are correct.