### PR TITLE
Fixed build with latest rtabmap version

### DIFF
--- a/rtabmap_conversions/src/MsgConversion.cpp
+++ b/rtabmap_conversions/src/MsgConversion.cpp
@@ -1650,9 +1650,8 @@ std::map<std::string, float> odomInfoToStatistics(const rtabmap::OdometryInfo & 
 	{
 		if(!info.transform.isNull())
 		{
-			rtabmap::Transform diff = info.transformGroundTruth.inverse()*info.transform;
-			stats.insert(std::make_pair("Odometry/TG_error_lin/m", diff.getNorm()));
-			stats.insert(std::make_pair("Odometry/TG_error_ang/deg", diff.getAngle()*180.0/CV_PI));
+			stats.insert(std::make_pair("Odometry/TG_error_lin/m", info.transformGroundTruth.getDistance(info.transform)));
+			stats.insert(std::make_pair("Odometry/TG_error_ang/deg", info.transformGroundTruth.getAngle(info.transform)*180.0/CV_PI));
 		}
 
 		info.transformGroundTruth.getTranslationAndEulerAngles(x,y,z,roll,pitch,yaw);


### PR DESCRIPTION
Backport of the fix applied in ros2 branch:

https://github.com/introlab/rtabmap_ros/commit/43d360ebb3e7b67c57c05a8c3f55f292f3d00f52

Fixes the build error due to the change in Transform::getAngle() requiring an explicit Transform argument.