### PR TITLE
Odom reset on time jump in the past

### DIFF
--- a/rtabmap_odom/include/rtabmap_odom/OdometryROS.h
+++ b/rtabmap_odom/include/rtabmap_odom/OdometryROS.h
@@ -159,6 +159,7 @@ private:
 	rtabmap::Transform guess_;
 	rtabmap::Transform guessPreviousPose_;
 	double previousStamp_;
+	double previousClockTime_;
 	double expectedUpdateRate_;
 	double maxUpdateRate_;
 	double minUpdateRate_;

--- a/rtabmap_odom/include/rtabmap_odom/OdometryROS.h
+++ b/rtabmap_odom/include/rtabmap_odom/OdometryROS.h
@@ -87,7 +87,7 @@ protected:
 	tf::TransformListener & tfListener() {return tfListener_;}
 	double waitForTransformDuration() const {return waitForTransform_?waitForTransformDuration_:0.0;}
 	rtabmap::Transform velocityGuess() const;
-	double previousStamp() const {return previousStamp_;}
+	ros::Time previousStamp() const {return previousStamp_;}
 	virtual void postProcessData(const rtabmap::SensorData & data, const std_msgs::Header & header) const {}
 
 private:
@@ -158,8 +158,8 @@ private:
 	bool icpParams_;
 	rtabmap::Transform guess_;
 	rtabmap::Transform guessPreviousPose_;
-	double previousStamp_;
-	double previousClockTime_;
+	ros::Time previousStamp_;
+	ros::Time previousClockTime_;
 	double expectedUpdateRate_;
 	double maxUpdateRate_;
 	double minUpdateRate_;

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -949,7 +949,7 @@ void OdometryROS::mainLoop()
 			Transform correction = odometry_->getPose() * guess_ * guessCurrentPose.inverse();
 			rtabmap_conversions::transformToGeometryMsg(correction, correctionMsg.transform);
 			ros::Time time_now = ros::Time::now();
-			if(time_now > correctionMsg.header.stamp) {
+			if(time_now >= previousClockTime_) {
 				tfBroadcaster_.sendTransform(correctionMsg);
 			}
 			else {

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -573,7 +573,13 @@ void OdometryROS::mainLoop()
 		}
 		previousClockTime_ = clockNow;
 
-		if(previousStamp_>0.0 && previousStamp_ >= header.stamp.toSec())
+		if(header.stamp.toSec() > clockNow) {
+			NODELET_WARN("Odometry: Detected topic's stamp in the future (topic=%fs now=%fs). "
+					"Aborting update!",
+					header.stamp.toSec(), clockNow);
+			return;
+		}
+		else if(previousStamp_>0.0 && previousStamp_ >= header.stamp.toSec())
 		{
 			NODELET_WARN("Odometry: Detected not valid consecutive stamps (previous=%fs new=%fs). "
 					"New stamp should be always greater than previous stamp. This new data is ignored. ",

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -551,16 +551,17 @@ void OdometryROS::mainLoop()
 			if(previousClockTime_>0.0 && previousClockTime_ > now)
 			{
 				NODELET_WARN("Odometry: Detected jump back in time of %f sec. Odometry is "
-					"automatically reset to latest computed pose! Skipping this frame.",
-					previousClockTime_ - now);
+					"automatically reset to latest computed pose! Skipping this frame (stamp=%f).",
+					previousClockTime_ - now, header.stamp.toSec());
 				this->reset(odometry_->getPose());
 				return;
 			}
 			else // topics received not in order?!
 			{
 				NODELET_WARN("Odometry: Detected not valid consecutive stamps (previous=%fs new=%fs). "
-						"New stamp should be always greater than previous stamp. This new data is ignored. ",
-						previousStamp_, header.stamp.toSec());
+						"New stamp should be always greater than previous stamp. Clock: previous=%f new=%f. This new data is ignored. ",
+						previousStamp_, header.stamp.toSec(),
+						previousClockTime_, now);
 				return;
 			}
 		}

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -555,7 +555,7 @@ void OdometryROS::mainLoop()
 			std_msgs::Header headerCpy = dataHeaderToProcess_;
 			double previousCpy = previousClockTime_;
 			this->reset(odometry_->getPose());
-			if(previousCpy < headerCpy.stamp.toSec()) {
+			if(previousCpy > headerCpy.stamp.toSec()) {
 				// new frame is using new clock, process it now
 				dataToProcess_ = dataCpy;
 				dataHeaderToProcess_ = headerCpy;

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -553,19 +553,20 @@ void OdometryROS::mainLoop()
 				previousClockTime_ - clockNow);
 			SensorData dataCpy = dataToProcess_;
 			std_msgs::Header headerCpy = dataHeaderToProcess_;
+			double previousCpy = previousClockTime_;
 			this->reset(odometry_->getPose());
-			if(previousClockTime_ < headerCpy.stamp.toSec()) {
+			if(previousCpy < headerCpy.stamp.toSec()) {
 				// new frame is using new clock, process it now
 				dataToProcess_ = dataCpy;
 				dataHeaderToProcess_ = headerCpy;
 				dataReady_.release();
 				NODELET_WARN("Odometry: Restarting with frame: %f (clock previous=%f, new=%f)",
-					headerCpy.stamp.toSec(), previousClockTime_, clockNow);
+					headerCpy.stamp.toSec(), previousCpy, clockNow);
 			}
 			else {
 				// skip that old frame
 				NODELET_WARN("Odometry: skipping frame: %f (clock previous=%f, new=%f)",
-					headerCpy.stamp.toSec(), previousClockTime_, clockNow);
+					headerCpy.stamp.toSec(), previousCpy, clockNow);
 			}
 			previousClockTime_ = clockNow;
 			return;

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -679,7 +679,18 @@ void OdometryROS::mainLoop()
 						correctionMsg.header.stamp = header.stamp;
 						Transform correction = odometry_->getPose() * guess_ * guessCurrentPose.inverse();
 						rtabmap_conversions::transformToGeometryMsg(correction, correctionMsg.transform);
-						tfBroadcaster_.sendTransform(correctionMsg);
+						ros::Time time_now = ros::Time::now();
+						if(time_now > correctionMsg.header.stamp) {
+							tfBroadcaster_.sendTransform(correctionMsg);
+						}
+						else {
+							ROS_WARN("TF %s->%s is not published because its stamp (%f) is greater "
+								"than current time (%f), possible time jump happened!",
+								correctionMsg.header.frame_id.c_str(),
+								correctionMsg.child_frame_id.c_str(),
+								correctionMsg.header.stamp.toSec(),
+								time_now.toSec());
+						}
 					}
 					guessPreviousPose_ = guessCurrentPose;
 					return;
@@ -733,11 +744,33 @@ void OdometryROS::mainLoop()
 				correctionMsg.header.stamp = header.stamp;
 				Transform correction = pose * guessCurrentPose.inverse();
 				rtabmap_conversions::transformToGeometryMsg(correction, correctionMsg.transform);
-				tfBroadcaster_.sendTransform(correctionMsg);
+				ros::Time time_now = ros::Time::now();
+				if(time_now > correctionMsg.header.stamp) {
+					tfBroadcaster_.sendTransform(correctionMsg);
+				}
+				else {
+					ROS_WARN("TF %s->%s is not published because its stamp (%f) is greater "
+						"than current time (%f), possible time jump happened!",
+						correctionMsg.header.frame_id.c_str(),
+						correctionMsg.child_frame_id.c_str(),
+						correctionMsg.header.stamp.toSec(),
+						time_now.toSec());
+				}
 			}
 			else
 			{
-				tfBroadcaster_.sendTransform(poseMsg);
+				ros::Time time_now = ros::Time::now();
+				if(time_now > poseMsg.header.stamp) {
+					tfBroadcaster_.sendTransform(poseMsg);
+				}
+				else {
+					ROS_WARN("TF %s->%s is not published because its stamp (%f) is greater "
+						"than current time (%f), possible time jump happened!",
+						poseMsg.header.frame_id.c_str(),
+						poseMsg.child_frame_id.c_str(),
+						poseMsg.header.stamp.toSec(),
+						time_now.toSec());
+				}
 			}
 		}
 
@@ -929,7 +962,18 @@ void OdometryROS::mainLoop()
 			correctionMsg.header.stamp = header.stamp;
 			Transform correction = odometry_->getPose() * guess_ * guessCurrentPose.inverse();
 			rtabmap_conversions::transformToGeometryMsg(correction, correctionMsg.transform);
-			tfBroadcaster_.sendTransform(correctionMsg);
+			ros::Time time_now = ros::Time::now();
+			if(time_now > correctionMsg.header.stamp) {
+				tfBroadcaster_.sendTransform(correctionMsg);
+			}
+			else {
+				ROS_WARN("TF %s->%s is not published because its stamp (%f) is greater "
+					"than current time (%f), possible time jump happened!",
+					correctionMsg.header.frame_id.c_str(),
+					correctionMsg.child_frame_id.c_str(),
+					correctionMsg.header.stamp.toSec(),
+					time_now.toSec());
+			}
 		}
 	}
 

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -551,10 +551,15 @@ void OdometryROS::mainLoop()
 			if(previousClockTime_>0.0 && previousClockTime_ > clockNow)
 			{
 				NODELET_WARN("Odometry: Detected jump back in time of %f sec. Odometry is "
-					"automatically reset to latest computed pose! Skipping this frame (stamp=%f).",
+					"automatically reset to latest computed pose! Restarting with initial frame (stamp=%f).",
 					previousClockTime_ - clockNow, header.stamp.toSec());
+				SensorData dataCpy = dataToProcess_;
+				std_msgs::Header headerCpy = dataHeaderToProcess_;
 				this->reset(odometry_->getPose());
+				dataToProcess_ = dataCpy;
+				dataHeaderToProcess_ = headerCpy;
 				previousClockTime_ = clockNow;
+				dataReady_.release(); // force reprocessing now
 				return;
 			}
 			else // topics received not in order?!

--- a/rtabmap_odom/src/nodelets/icp_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/icp_odometry.cpp
@@ -380,11 +380,11 @@ private:
 					-1.0,
 					laser_geometry::channel_option::Intensity | laser_geometry::channel_option::Timestamp);
 
-			if(guessFrameId().empty() && previousStamp() > 0 && !velocityGuess().isNull())
+			if(guessFrameId().empty() && previousStamp().toSec() > 0.0 && !velocityGuess().isNull())
 			{
 				// deskew with constant velocity model (we are in frameId)
 				sensor_msgs::PointCloud2 scanOutDeskewed;
-				if(!rtabmap_conversions::deskew(scanOut, scanOutDeskewed, previousStamp(), velocityGuess()))
+				if(!rtabmap_conversions::deskew(scanOut, scanOutDeskewed, previousStamp().toSec(), velocityGuess()))
 				{
 					ROS_ERROR("Failed to deskew input cloud, aborting odometry update!");
 					return;
@@ -405,11 +405,11 @@ private:
 		{
 			projection.projectLaser(*scanMsg, scanOut, -1.0, laser_geometry::channel_option::Intensity | laser_geometry::channel_option::Timestamp);
 
-			if(deskewing_ && previousStamp() > 0 && !velocityGuess().isNull())
+			if(deskewing_ && previousStamp().toSec() > 0.0 && !velocityGuess().isNull())
 			{
 				// deskew with constant velocity model
 				sensor_msgs::PointCloud2 scanOutDeskewed;
-				if(!rtabmap_conversions::deskew(scanOut, scanOutDeskewed, previousStamp(), velocityGuess()))
+				if(!rtabmap_conversions::deskew(scanOut, scanOutDeskewed, previousStamp().toSec(), velocityGuess()))
 				{
 					ROS_ERROR("Failed to deskew input cloud, aborting odometry update!");
 					return;
@@ -628,7 +628,7 @@ private:
 					return;
 				}
 			}
-			else if(previousStamp() > 0 && !velocityGuess().isNull())
+			else if(previousStamp().toSec() > 0.0 && !velocityGuess().isNull())
 			{
 				// deskew with constant velocity model
 				bool alreadyInBaseFrame = frameId().compare(pointCloudMsg->header.frame_id) == 0;
@@ -648,7 +648,7 @@ private:
 				}
 
 				sensor_msgs::PointCloud2::Ptr cloudDeskewed(new sensor_msgs::PointCloud2);
-				if(!rtabmap_conversions::deskew(*cloudPtr, *cloudDeskewed, previousStamp(), velocityGuess()))
+				if(!rtabmap_conversions::deskew(*cloudPtr, *cloudDeskewed, previousStamp().toSec(), velocityGuess()))
 				{
 					ROS_ERROR("Failed to deskew input cloud, aborting odometry update!");
 					return;

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -1023,6 +1023,14 @@ bool CoreWrapper::odomUpdate(const nav_msgs::OdometryConstPtr & odomMsg, ros::Ti
 {
 	if(!paused_)
 	{
+		// Check time jump in the past
+		if(previousStamp_.toSec()>0.0 && stamp.toSec() < previousStamp_) {
+			ROS_WARN("Detected time jump in the past of %f sec (previous stamp=%f, current stamp=%f). Resetting internal stamps and abort!",
+				previousStamp_.toSec() - stamp.toSec(), previousStamp_.toSec(), stamp.toSec());
+			previousStamp_ = ros::Time();
+			return false;
+		}
+
 		Transform odom = rtabmap_conversions::transformFromPoseMsg(odomMsg->pose.pose);
 		if(!odom.isNull())
 		{
@@ -1134,6 +1142,14 @@ bool CoreWrapper::odomTFUpdate(const ros::Time & stamp)
 {
 	if(!paused_)
 	{
+		// Check time jump in the past
+		if(previousStamp_.toSec()>0.0 && stamp.toSec() < previousStamp_) {
+			ROS_WARN("Detected time jump in the past of %f sec (previous stamp=%f, current stamp=%f). Resetting internal stamps and abort!",
+				previousStamp_.toSec() - stamp.toSec(), previousStamp_.toSec(), stamp.toSec());
+			previousStamp_ = ros::Time();
+			return false;
+		}
+
 		// Odom TF ready?
 		Transform odom = rtabmap_conversions::getTransform(odomFrameId_, frameId_, stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
 		if(odom.isNull())

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -1024,10 +1024,11 @@ bool CoreWrapper::odomUpdate(const nav_msgs::OdometryConstPtr & odomMsg, ros::Ti
 	if(!paused_)
 	{
 		// Check time jump in the past
-		if(previousStamp_.toSec()>0.0 && stamp < previousStamp_) {
+		if(stamp < previousStamp_) {
 			ROS_WARN("Detected time jump in the past of %f sec (previous stamp=%f, current stamp=%f). Resetting internal stamps and abort!",
 				previousStamp_.toSec() - stamp.toSec(), previousStamp_.toSec(), stamp.toSec());
 			previousStamp_ = ros::Time();
+			tfListener_.clear();
 			return false;
 		}
 
@@ -1143,10 +1144,11 @@ bool CoreWrapper::odomTFUpdate(const ros::Time & stamp)
 	if(!paused_)
 	{
 		// Check time jump in the past
-		if(previousStamp_.toSec()>0.0 && stamp < previousStamp_) {
+		if(stamp < previousStamp_) {
 			ROS_WARN("Detected time jump in the past of %f sec (previous stamp=%f, current stamp=%f). Resetting internal stamps and abort!",
 				previousStamp_.toSec() - stamp.toSec(), previousStamp_.toSec(), stamp.toSec());
 			previousStamp_ = ros::Time();
+			tfListener_.clear();
 			return false;
 		}
 

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -1024,7 +1024,7 @@ bool CoreWrapper::odomUpdate(const nav_msgs::OdometryConstPtr & odomMsg, ros::Ti
 	if(!paused_)
 	{
 		// Check time jump in the past
-		if(previousStamp_.toSec()>0.0 && stamp.toSec() < previousStamp_) {
+		if(previousStamp_.toSec()>0.0 && stamp < previousStamp_) {
 			ROS_WARN("Detected time jump in the past of %f sec (previous stamp=%f, current stamp=%f). Resetting internal stamps and abort!",
 				previousStamp_.toSec() - stamp.toSec(), previousStamp_.toSec(), stamp.toSec());
 			previousStamp_ = ros::Time();
@@ -1143,7 +1143,7 @@ bool CoreWrapper::odomTFUpdate(const ros::Time & stamp)
 	if(!paused_)
 	{
 		// Check time jump in the past
-		if(previousStamp_.toSec()>0.0 && stamp.toSec() < previousStamp_) {
+		if(previousStamp_.toSec()>0.0 && stamp < previousStamp_) {
 			ROS_WARN("Detected time jump in the past of %f sec (previous stamp=%f, current stamp=%f). Resetting internal stamps and abort!",
 				previousStamp_.toSec() - stamp.toSec(), previousStamp_.toSec(), stamp.toSec());
 			previousStamp_ = ros::Time();

--- a/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
+++ b/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
@@ -86,10 +86,10 @@ class SyncDiagnostic {
         if(lastTickTime_ > clockNow)
         {
             ROS_WARN("%s: Detected time jump in the past of %f sec, forcing diagnostic update.", 
-                nodeName_.c_str(), clockNow - lastTickTime_);
+                nodeName_.c_str(), lastTickTime_ - clockNow);
             diagnosticUpdater_.force_update();
-            diagnosticTimer_.stop();
-            diagnosticTimer_.start();
+            diagnosticTimer_.setPeriod(ros::Duration(1));
+            lastCallbackCalledStamp_ = clockNow;
         }
         else
         {

--- a/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
+++ b/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
@@ -90,7 +90,6 @@ class SyncDiagnostic {
             frequencyStatus_.clear();
             diagnosticUpdater_.force_update();
             lastCallbackCalledStamp_ = clockNow;
-            diagnosticTimer_.setPeriod(ros::Duration(5));
         }
         else
         {

--- a/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
+++ b/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
@@ -48,7 +48,7 @@ class SyncDiagnostic {
         }
         diagnosticUpdater_.setHardwareID(strList.empty()?"none":uJoin(strList, "/"));
         diagnosticUpdater_.force_update();
-        diagnosticTimer_ = ros::NodeHandle().createTimer(ros::Duration(1), &SyncDiagnostic::diagnosticTimerCallback, this);
+        diagnosticTimer_ = ros::NodeHandle().createTimer(ros::Duration(5), &SyncDiagnostic::diagnosticTimerCallback, this);
     }
 
     void tick(const ros::Time & stamp, double targetFrequency = 0)
@@ -87,8 +87,10 @@ class SyncDiagnostic {
         {
             ROS_WARN("%s: Detected time jump in the past of %f sec, forcing diagnostic update.", 
                 nodeName_.c_str(), lastTickTime_ - clockNow);
+            frequencyStatus_.clear();
             diagnosticUpdater_.force_update();
             lastCallbackCalledStamp_ = clockNow;
+            diagnosticTimer_.setPeriod(ros::Duration(5));
         }
         else
         {
@@ -102,7 +104,7 @@ private:
     {
         if(ros::Time::now().toSec()-lastCallbackCalledStamp_ >= 5 && !topicsNotReceivedWarningMsg_.empty())
         {
-            ROS_WARN_THROTTLE(5, "%s", topicsNotReceivedWarningMsg_.c_str());
+            ROS_WARN("%s", topicsNotReceivedWarningMsg_.c_str());
         }
     }
 

--- a/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
+++ b/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
@@ -19,7 +19,9 @@ class SyncDiagnostic {
             compositeTask_("Sync status"),
             lastCallbackCalledStamp_(ros::Time::now().toSec()-1),
             targetFrequency_(0.0),
-            windowSize_(windowSize)
+            windowSize_(windowSize),
+            lastTickTime_(0.0),
+            nodeName_(nodeName)
     {
         UASSERT(windowSize_ >= 1);
     }
@@ -83,7 +85,8 @@ class SyncDiagnostic {
         double clockNow = ros::Time::now().toSec();
         if(lastTickTime_ > clockNow)
         {
-            ROS_WARN("Detected time jump in the past of %f sec, forcing diagnostic update.", clockNow - lastTickTime_);
+            ROS_WARN("%s: Detected time jump in the past of %f sec, forcing diagnostic update.", 
+                nodeName_.c_str(), clockNow - lastTickTime_);
             diagnosticUpdater_.force_update();
             diagnosticTimer_.stop();
             diagnosticTimer_.start();
@@ -116,6 +119,7 @@ private:
         int windowSize_;
         std::deque<double> window_;
         double lastTickTime_;
+        std::string nodeName_;
 
 };
 

--- a/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
+++ b/rtabmap_sync/include/rtabmap_sync/SyncDiagnostic.h
@@ -88,7 +88,6 @@ class SyncDiagnostic {
             ROS_WARN("%s: Detected time jump in the past of %f sec, forcing diagnostic update.", 
                 nodeName_.c_str(), lastTickTime_ - clockNow);
             diagnosticUpdater_.force_update();
-            diagnosticTimer_.setPeriod(ros::Duration(1));
             lastCallbackCalledStamp_ = clockNow;
         }
         else


### PR DESCRIPTION
When the clock is jumping in the past (for some reason: ntp sync or something) while visual odometry (vo) is running, vo will detect non incremental timestamps, then skip all new frames till a new frame has stamp higher than latest added frame. If the jump is 10 seconds in the past, it means VO won't update for 10 seconds. We added that check in the past for rosbags having flaky sensor data where sometimes topics would arrived unordered. However, if it is caused by a clock jump, we should reset as soon as possible. This PR is doing that, while still skipping frames in case of flaky input data stream (not related to clock jumping).

