### PR TITLE
Adding aruco msgs input support

### DIFF
--- a/rtabmap_slam/CMakeLists.txt
+++ b/rtabmap_slam/CMakeLists.txt
@@ -38,6 +38,9 @@ find_package(rtabmap_sync REQUIRED)
 
 #optional
 find_package(apriltag_msgs)
+find_package(aruco_msgs)
+find_package(aruco_markers_msgs)
+find_package(aruco_opencv_msgs)
 find_package(nav2_msgs)
 
 IF(WIN32)
@@ -87,6 +90,36 @@ SET(Libraries
    apriltag_msgs
 )
 ENDIF(apriltag_msgs_FOUND)
+
+# If aruco_msgs is found, add definition
+IF(aruco_msgs_FOUND)
+MESSAGE(STATUS "WITH aruco_msgs")
+ADD_DEFINITIONS("-DWITH_ARUCO_MSGS")
+SET(Libraries
+   ${Libraries}
+   aruco_msgs
+)
+ENDIF(aruco_msgs_FOUND)
+
+# If aruco_opencv_msgs is found, add definition
+IF(aruco_opencv_msgs_FOUND)
+MESSAGE(STATUS "WITH aruco_opencv_msgs")
+ADD_DEFINITIONS("-DWITH_ARUCO_OPENCV_MSGS")
+SET(Libraries
+   ${Libraries}
+   aruco_opencv_msgs
+)
+ENDIF(aruco_opencv_msgs_FOUND)
+
+# If aruco_markers_msgs is found, add definition
+IF(aruco_markers_msgs_FOUND)
+MESSAGE(STATUS "WITH aruco_markers_msgs")
+ADD_DEFINITIONS("-DWITH_ARUCO_MARKERS_MSGS")
+SET(Libraries
+   ${Libraries}
+   aruco_markers_msgs
+)
+ENDIF(aruco_markers_msgs_FOUND)
 
 # If nav2_msgs is found, add definition
 IF(nav2_msgs_FOUND)

--- a/rtabmap_slam/CMakeLists.txt
+++ b/rtabmap_slam/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(apriltag_msgs)
 find_package(aruco_msgs)
 find_package(aruco_markers_msgs)
 find_package(aruco_opencv_msgs)
+find_package(ros2_aruco_interfaces)
 find_package(nav2_msgs)
 
 IF(WIN32)
@@ -120,6 +121,16 @@ SET(Libraries
    aruco_markers_msgs
 )
 ENDIF(aruco_markers_msgs_FOUND)
+
+# If ros2_aruco_interfaces is found, add definition
+IF(ros2_aruco_interfaces_FOUND)
+MESSAGE(STATUS "WITH ros2_aruco_interfaces")
+ADD_DEFINITIONS("-DWITH_ROS2_ARUCO_INTERFACES")
+SET(Libraries
+   ${Libraries}
+   ros2_aruco_interfaces
+)
+ENDIF(ros2_aruco_interfaces_FOUND)
 
 # If nav2_msgs is found, add definition
 IF(nav2_msgs_FOUND)

--- a/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
+++ b/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
@@ -100,6 +100,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <aruco_markers_msgs/msg/marker_array.hpp>
 #endif
 
+#ifdef WITH_ROS2_ARUCO_INTERFACES
+#include <ros2_aruco_interfaces/msg/aruco_markers.hpp>
+#endif
+
 #ifdef WITH_NAV2_MSGS
 #include <nav2_msgs/action/navigate_to_pose.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
@@ -190,16 +194,20 @@ private:
 	void landmarkDetectionAsyncCallback(const rtabmap_msgs::msg::LandmarkDetection::SharedPtr landmarkDetection);
 	void landmarkDetectionsAsyncCallback(const rtabmap_msgs::msg::LandmarkDetections::SharedPtr landmarkDetections);
 #ifdef WITH_APRILTAG_MSGS
-	void tagDetectionsAsyncCallback(const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr tagDetections);
+	void tagDetectionsAsyncCallback(const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr msg);
+	void apriltagAsyncCallback(const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr msg);
 #endif
 #ifdef WITH_ARUCO_MSGS
-	void arucoAsyncCallback(const aruco_msgs::msg::MarkerArray::SharedPtr tagDetections);
+	void arucoAsyncCallback(const aruco_msgs::msg::MarkerArray::SharedPtr msg);
 #endif
 #ifdef WITH_ARUCO_OPENCV_MSGS
-	void arucoCvAsyncCallback(const aruco_opencv_msgs::msg::ArucoDetection::SharedPtr tagDetections);
+	void arucoOpencvAsyncCallback(const aruco_opencv_msgs::msg::ArucoDetection::SharedPtr msg);
 #endif
 #ifdef WITH_ARUCO_MARKERS_MSGS
-	void arucoMarkersAsyncCallback(const aruco_markers_msgs::msg::MarkerArray::SharedPtr tagDetections);
+	void arucoMarkersAsyncCallback(const aruco_markers_msgs::msg::MarkerArray::SharedPtr msg);
+#endif
+#ifdef WITH_ROS2_ARUCO_INTERFACES
+	void arucoInterfacesAsyncCallback(const ros2_aruco_interfaces::msg::ArucoMarkers::SharedPtr msg);
 #endif
 #ifdef WITH_FIDUCIAL_MSGS
 	void fiducialDetectionsAsyncCallback(const fiducial_msgs::msgs::FiducialTransformArray::SharedPtr fiducialDetections);
@@ -441,15 +449,19 @@ private:
 	rclcpp::Subscription<rtabmap_msgs::msg::LandmarkDetections>::SharedPtr landmarkDetectionsSub_;
 #ifdef WITH_APRILTAG_MSGS
 	rclcpp::Subscription<apriltag_msgs::msg::AprilTagDetectionArray>::SharedPtr tagDetectionsSub_;
+	rclcpp::Subscription<apriltag_msgs::msg::AprilTagDetectionArray>::SharedPtr apriltagSub_;
 #endif
 #ifdef WITH_ARUCO_MSGS
-	rclcpp::Subscription<aruco_msgs::msg::MarkerArray>::SharedPtr arucoDetectionsSub_;
+	rclcpp::Subscription<aruco_msgs::msg::MarkerArray>::SharedPtr arucoSub_;
 #endif
 #ifdef WITH_ARUCO_OPENCV_MSGS
-	rclcpp::Subscription<aruco_opencv_msgs::msg::ArucoDetection>::SharedPtr arucoCvDetectionsSub_;
+	rclcpp::Subscription<aruco_opencv_msgs::msg::ArucoDetection>::SharedPtr arucoOpencvSub_;
 #endif
 #ifdef WITH_ARUCO_MARKERS_MSGS
 	rclcpp::Subscription<aruco_markers_msgs::msg::MarkerArray>::SharedPtr arucoMarkersSub_;
+#endif
+#ifdef WITH_ROS2_ARUCO_INTERFACES
+	rclcpp::Subscription<ros2_aruco_interfaces::msg::ArucoMarkers>::SharedPtr arucoInterfacesSub_;
 #endif
 #ifdef WITH_FIDUCIAL_MSGS
 	rclcpp::Subscription<fiducial_msgs::msg::FiducialTransformArray>::SharedPtr fiducialTransfromsSub_;

--- a/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
+++ b/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
@@ -88,6 +88,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <apriltag_msgs/msg/april_tag_detection_array.hpp>
 #endif
 
+#ifdef WITH_ARUCO_MSGS
+#include <aruco_msgs/msg/marker_array.hpp>
+#endif
+
+#ifdef WITH_ARUCO_OPENCV_MSGS
+#include <aruco_opencv_msgs/msg/aruco_detection.hpp>
+#endif
+
+#ifdef WITH_ARUCO_MARKERS_MSGS
+#include <aruco_markers_msgs/msg/marker_array.hpp>
+#endif
+
 #ifdef WITH_NAV2_MSGS
 #include <nav2_msgs/action/navigate_to_pose.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
@@ -179,6 +191,15 @@ private:
 	void landmarkDetectionsAsyncCallback(const rtabmap_msgs::msg::LandmarkDetections::SharedPtr landmarkDetections);
 #ifdef WITH_APRILTAG_MSGS
 	void tagDetectionsAsyncCallback(const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr tagDetections);
+#endif
+#ifdef WITH_ARUCO_MSGS
+	void arucoAsyncCallback(const aruco_msgs::msg::MarkerArray::SharedPtr tagDetections);
+#endif
+#ifdef WITH_ARUCO_OPENCV_MSGS
+	void arucoCvAsyncCallback(const aruco_opencv_msgs::msg::ArucoDetection::SharedPtr tagDetections);
+#endif
+#ifdef WITH_ARUCO_MARKERS_MSGS
+	void arucoMarkersAsyncCallback(const aruco_markers_msgs::msg::MarkerArray::SharedPtr tagDetections);
 #endif
 #ifdef WITH_FIDUCIAL_MSGS
 	void fiducialDetectionsAsyncCallback(const fiducial_msgs::msgs::FiducialTransformArray::SharedPtr fiducialDetections);
@@ -420,6 +441,15 @@ private:
 	rclcpp::Subscription<rtabmap_msgs::msg::LandmarkDetections>::SharedPtr landmarkDetectionsSub_;
 #ifdef WITH_APRILTAG_MSGS
 	rclcpp::Subscription<apriltag_msgs::msg::AprilTagDetectionArray>::SharedPtr tagDetectionsSub_;
+#endif
+#ifdef WITH_ARUCO_MSGS
+	rclcpp::Subscription<aruco_msgs::msg::MarkerArray>::SharedPtr arucoDetectionsSub_;
+#endif
+#ifdef WITH_ARUCO_OPENCV_MSGS
+	rclcpp::Subscription<aruco_opencv_msgs::msg::ArucoDetection>::SharedPtr arucoCvDetectionsSub_;
+#endif
+#ifdef WITH_ARUCO_MARKERS_MSGS
+	rclcpp::Subscription<aruco_markers_msgs::msg::MarkerArray>::SharedPtr arucoMarkersSub_;
 #endif
 #ifdef WITH_FIDUCIAL_MSGS
 	rclcpp::Subscription<fiducial_msgs::msg::FiducialTransformArray>::SharedPtr fiducialTransfromsSub_;

--- a/rtabmap_slam/package.xml
+++ b/rtabmap_slam/package.xml
@@ -27,6 +27,9 @@
   <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
   <depend>apriltag_msgs</depend>
+  <depend>aruco_msgs</depend>
+  <depend>aruco_opencv_msgs</depend>
+  <!-- depend>aruco_markers_msgs</depend --> <!-- binaries only available on humble -->
   
   <depend>rtabmap_msgs</depend>
   <depend>rtabmap_util</depend>

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -886,15 +886,19 @@ CoreWrapper::CoreWrapper(const rclcpp::NodeOptions & options) :
 	landmarkDetectionsSub_ = this->create_subscription<rtabmap_msgs::msg::LandmarkDetections>("landmark_detections", 1, std::bind(&CoreWrapper::landmarkDetectionsAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
 #ifdef WITH_APRILTAG_MSGS
 	tagDetectionsSub_ = this->create_subscription<apriltag_msgs::msg::AprilTagDetectionArray>("tag_detections", 5, std::bind(&CoreWrapper::tagDetectionsAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
+	apriltagSub_ = this->create_subscription<apriltag_msgs::msg::AprilTagDetectionArray>("apriltag/detections", 5, std::bind(&CoreWrapper::apriltagAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
 #endif
 #ifdef WITH_ARUCO_MSGS
-	arucoDetectionsSub_ = this->create_subscription<aruco_msgs::msg::MarkerArray>("marker_publisher/markers", 5, std::bind(&CoreWrapper::arucoAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
+	arucoSub_ = this->create_subscription<aruco_msgs::msg::MarkerArray>("aruco/detections", 5, std::bind(&CoreWrapper::arucoAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
 #endif
 #ifdef WITH_ARUCO_OPENCV_MSGS
-	arucoCvDetectionsSub_ = this->create_subscription<aruco_opencv_msgs::msg::ArucoDetection>("aruco_detections", 5, std::bind(&CoreWrapper::arucoCvAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
+	arucoOpencvSub_ = this->create_subscription<aruco_opencv_msgs::msg::ArucoDetection>("aruco_opencv/detections", 5, std::bind(&CoreWrapper::arucoOpencvAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
 #endif
 #ifdef WITH_ARUCO_MARKERS_MSGS
-	arucoMarkersSub_ = this->create_subscription<aruco_markers_msgs::msg::MarkerArray>("aruco/markers", 5, std::bind(&CoreWrapper::arucoMarkersAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
+	arucoMarkersSub_ = this->create_subscription<aruco_markers_msgs::msg::MarkerArray>("aruco_markers/detections", 5, std::bind(&CoreWrapper::arucoMarkersAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
+#endif
+#ifdef WITH_ROS2_ARUCO_INTERFACES
+	arucoInterfacesSub_ = this->create_subscription<ros2_aruco_interfaces::msg::ArucoMarkers>("aruco_interfaces/detections", 5, std::bind(&CoreWrapper::arucoInterfacesAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
 #endif
 #ifdef WITH_FIDUCIAL_MSGS
 	fiducialTransfromsSub_ = this->create_subscription<fiducial_msgs::msg::FiducialTransformArray>("fiducial_transforms", 5, std::bind(&CoreWrapper::fiducialDetectionsAsyncCallback, this, std::placeholders::_1), landmarkSubOptions);
@@ -2660,18 +2664,30 @@ void CoreWrapper::landmarkDetectionsAsyncCallback(const rtabmap_msgs::msg::Landm
 }
 
 #ifdef WITH_APRILTAG_MSGS
-void CoreWrapper::tagDetectionsAsyncCallback(const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr tagDetections)
+void CoreWrapper::tagDetectionsAsyncCallback(const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr msg)
+{
+	if(!paused_)
+	{
+		static bool warningShow = false;
+		if(!warningShow) {
+			RCLCPP_WARN(this->get_logger(), "\"tag_detections\" input topic name for apriltag_msgs is deprecated, remap \"apriltag\" input topic name instead. This message is only printed once.");
+			warningShow = true;
+		}
+		apriltagAsyncCallback(msg);
+	}
+}
+void CoreWrapper::apriltagAsyncCallback(const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr msg)
 {
 	if(!paused_)
 	{
 		UScopeMutex lock(landmarksMutex_);
-		for(unsigned int i=0; i<tagDetections->detections.size(); ++i)
+		for(unsigned int i=0; i<msg->detections.size(); ++i)
 		{
-			std::string tagFrameId = tagDetections->detections[i].family+":"+uNumber2Str(tagDetections->detections[i].id);
+			std::string tagFrameId = msg->detections[i].family+":"+uNumber2Str(msg->detections[i].id);
 			Transform camToTag = rtabmap_conversions::getTransform(
-				tagDetections->header.frame_id, // e.g., camera_optical_frame
+				msg->header.frame_id, // e.g., camera_optical_frame
 				tagFrameId,                     // e.g., tag36h11:42
-				tagDetections->header.stamp,
+				msg->header.stamp,
 				*tfBuffer_,
 				waitForTransform_);
 			if(camToTag.isNull())
@@ -2679,16 +2695,16 @@ void CoreWrapper::tagDetectionsAsyncCallback(const apriltag_msgs::msg::AprilTagD
 				RCLCPP_WARN(get_logger(), "Could not get TF between %s and %s frames for tag detection %d.",
 					frameId_.c_str(),
 					tagFrameId.c_str(),
-					tagDetections->detections[i].id);
+					msg->detections[i].id);
 					continue;
 			}
 
 			geometry_msgs::msg::PoseWithCovarianceStamped p;
 			rtabmap_conversions::transformToPoseMsg(camToTag, p.pose.pose);
-			p.header = tagDetections->header;
+			p.header = msg->header;
 			
 			uInsert(landmarks_,
-					std::make_pair(tagDetections->detections[i].id,
+					std::make_pair(msg->detections[i].id,
 							std::make_pair(p, 0.0f)));
 		}
 	}
@@ -2696,19 +2712,19 @@ void CoreWrapper::tagDetectionsAsyncCallback(const apriltag_msgs::msg::AprilTagD
 #endif
 
 #ifdef WITH_ARUCO_MSGS
-void CoreWrapper::arucoAsyncCallback(const aruco_msgs::msg::MarkerArray::SharedPtr tagDetections)
+void CoreWrapper::arucoAsyncCallback(const aruco_msgs::msg::MarkerArray::SharedPtr msg)
 {
 	if(!paused_)
 	{
 		UScopeMutex lock(landmarksMutex_);
-		for(unsigned int i=0; i<tagDetections->markers.size(); ++i)
+		for(unsigned int i=0; i<msg->markers.size(); ++i)
 		{
 			geometry_msgs::msg::PoseWithCovarianceStamped p;
-			p.pose = tagDetections->markers[i].pose;
-			p.header = tagDetections->markers[i].header;
+			p.pose = msg->markers[i].pose;
+			p.header = msg->markers[i].header;
 
 			uInsert(landmarks_,
-					std::make_pair((int)tagDetections->markers[i].id,
+					std::make_pair((int)msg->markers[i].id,
 							std::make_pair(p, 0.0f)));
 		}
 	}
@@ -2716,19 +2732,19 @@ void CoreWrapper::arucoAsyncCallback(const aruco_msgs::msg::MarkerArray::SharedP
 #endif
 
 #ifdef WITH_ARUCO_OPENCV_MSGS
-void CoreWrapper::arucoCvAsyncCallback(const aruco_opencv_msgs::msg::ArucoDetection::SharedPtr tagDetections)
+void CoreWrapper::arucoOpencvAsyncCallback(const aruco_opencv_msgs::msg::ArucoDetection::SharedPtr msg)
 {
 	if(!paused_)
 	{
 		UScopeMutex lock(landmarksMutex_);
-		for(unsigned int i=0; i<tagDetections->markers.size(); ++i)
+		for(unsigned int i=0; i<msg->markers.size(); ++i)
 		{
 			geometry_msgs::msg::PoseWithCovarianceStamped p;
-			p.pose.pose = tagDetections->markers[i].pose;
-			p.header = tagDetections->header;
+			p.pose.pose = msg->markers[i].pose;
+			p.header = msg->header;
 			
 			uInsert(landmarks_,
-					std::make_pair((int)tagDetections->markers[i].marker_id,
+					std::make_pair((int)msg->markers[i].marker_id,
 							std::make_pair(p, 0.0f)));
 		}
 	}
@@ -2736,19 +2752,40 @@ void CoreWrapper::arucoCvAsyncCallback(const aruco_opencv_msgs::msg::ArucoDetect
 #endif
 
 #ifdef WITH_ARUCO_MARKERS_MSGS
-void CoreWrapper::arucoMarkersAsyncCallback(const aruco_markers_msgs::msg::MarkerArray::SharedPtr tagDetections)
+void CoreWrapper::arucoMarkersAsyncCallback(const aruco_markers_msgs::msg::MarkerArray::SharedPtr msg)
 {
 	if(!paused_)
 	{
 		UScopeMutex lock(landmarksMutex_);
-		for(unsigned int i=0; i<tagDetections->markers.size(); ++i)
+		for(unsigned int i=0; i<msg->markers.size(); ++i)
 		{
 			geometry_msgs::msg::PoseWithCovarianceStamped p;
-			p.pose.pose = tagDetections->markers[i].pose.pose;
-			p.header = tagDetections->markers[i].pose.header;
+			p.pose.pose = msg->markers[i].pose.pose;
+			p.header = msg->markers[i].pose.header;
 			
 			uInsert(landmarks_,
-					std::make_pair((int)tagDetections->markers[i].id,
+					std::make_pair((int)msg->markers[i].id,
+							std::make_pair(p, 0.0f)));
+		}
+	}
+}
+#endif
+
+#ifdef WITH_ROS2_ARUCO_INTERFACES
+void CoreWrapper::arucoInterfacesAsyncCallback(const ros2_aruco_interfaces::msg::ArucoMarkers::SharedPtr msg)
+{
+	if(!paused_)
+	{
+		UScopeMutex lock(landmarksMutex_);
+		UASSERT(msg->marker_ids.size() == msg->poses.size());
+		for(unsigned int i=0; i<msg->marker_ids.size(); ++i)
+		{
+			geometry_msgs::msg::PoseWithCovarianceStamped p;
+			p.pose.pose = msg->poses[i];
+			p.header = msg->header;
+			
+			uInsert(landmarks_,
+					std::make_pair((int)msg->marker_ids[i],
 							std::make_pair(p, 0.0f)));
 		}
 	}


### PR DESCRIPTION
See https://github.com/introlab/rtabmap/issues/377

Aruco generator: https://chev.me/arucogen/

Camera:
```
ros2 launch rtabmap_examples realsense_d435i_infra.launch.py
```

* For [aruco_msgs](https://github.com/pal-robotics/aruco_ros) (Original Aruco marker dictionary should be used):
    ```
    ros2 run aruco_ros marker_publisher --ros-args \
   -r  camera_info:=/camera/infra1/camera_info \
   -r image:=/camera/infra1/image_rect_raw \
   -p marker_size:=0.11 \
   -p camera_frame:=camera_infra1_optical_frame \
   -r marker_publisher/markers:=aruco/detections
    ```
* For [aruco_opencv_msgs](https://github.com/fictionlab/ros_aruco_opencv):
    ```
    ros2 run aruco_opencv aruco_tracker --ros-args  \
   -p cam_base_topic:=/camera/infra1/image_rect_raw \
   -p marker_size:=0.11 \
   -p image_is_rectified:=true \
   -p marker_dict:="4X4_50" \
   -r aruco_detections:=aruco_opencv/detections

   ros2 lifecycle set /aruco_tracker configure
   ros2 lifecycle set /aruco_tracker activate
    ```
* For [aruco_markers_msgs](https://github.com/namo-robotics/aruco_markers):
    ```
   ros2 run aruco_markers aruco_markers --ros-args \
   -p marker_size:=0.11 \
   -p camera_frame:=camera_infra1_optical_frame \
   -p image_topic:=/camera/infra1/image_rect_raw \
   -p camera_info_topic:=/camera/infra1/camera_info \
   -p dictionary:=DICT_4X4_50 \
   -r aruco/markers:=aruco_markers/detections
    ```
* For [ros2_aruco_interfaces](https://github.com/JMU-ROBOTICS-VIVA/ros2_aruco):
   ```
   ros2 run ros2_aruco aruco_node --ros-args \
   -p marker_size:=0.11 \
   -p aruco_dictionary_id:=DICT_4X4_50 \
   -p image_topic:=/camera/infra1/image_rect_raw \
   -p camera_info_topic:=/camera/infra1/camera_info \
   -r aruco_markers:=aruco_interfaces/detections
   ```
* For [apriltag_msgs](https://github.com/christianrauch/apriltag_ros):
   ```
   ros2 run apriltag_ros apriltag_node --ros-args \
    -r image_rect:=/camera/infra1/image_rect_raw \
    -r camera_info:=/camera/infra1/camera_info \
    -p size:=0.11 \
    -p family:=36h11 \
    -r detections:=apriltag/detections
   ```

Note: we deprecated `tag_detections` topic for `apriltag/detections`.
