### PR TITLE
Resolving image_transport hints support (#1181)

### DIFF
--- a/.devcontainer/humble/Dockerfile
+++ b/.devcontainer/humble/Dockerfile
@@ -8,7 +8,9 @@ ARG USER_GID=1000
 RUN set -ex && \
     groupadd --gid ${USER_GID} ${USERNAME} && \
     useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} && \
-    usermod -a -G sudo ${USERNAME}
+    usermod -a -G sudo ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${USERNAME}
 
 RUN mkdir -p /home/${USERNAME}/ros2_ws/src && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/ros2_ws

--- a/.devcontainer/jazzy/Dockerfile
+++ b/.devcontainer/jazzy/Dockerfile
@@ -11,7 +11,9 @@ ARG USER_GID=1000
 RUN set -ex && \
     groupadd --gid ${USER_GID} ${USERNAME} && \
     useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} && \
-    usermod -a -G sudo ${USERNAME}
+    usermod -a -G sudo ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${USERNAME}
 
 RUN mkdir -p /home/${USERNAME}/ros2_ws/src && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/ros2_ws

--- a/.devcontainer/kilted/Dockerfile
+++ b/.devcontainer/kilted/Dockerfile
@@ -11,7 +11,9 @@ ARG USER_GID=1000
 RUN set -ex && \
     groupadd --gid ${USER_GID} ${USERNAME} && \
     useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} && \
-    usermod -a -G sudo ${USERNAME}
+    usermod -a -G sudo ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${USERNAME}
 
 RUN mkdir -p /home/${USERNAME}/ros2_ws/src && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/ros2_ws

--- a/rtabmap_odom/src/nodelets/rgbd_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/rgbd_odometry.cpp
@@ -364,8 +364,8 @@ void RGBDOdometry::onOdomInit()
 	{
 		image_transport::TransportHints rgb_hints(this); // using "image_transport" parameter
 		image_transport::TransportHints depth_hints(this, "raw", "depth_transport");
-		std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-		std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 		image_mono_sub_.subscribe(this, rgbTopic, rgb_hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
 		image_depth_sub_.subscribe(this, depthTopic, depth_hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
 		info_sub_.subscribe(this, "rgb/camera_info", RCLCPP_QOS(topicQueueSize_, qosCamInfo), options);

--- a/rtabmap_odom/src/nodelets/rgbd_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/rgbd_odometry.cpp
@@ -113,8 +113,16 @@ void RGBDOdometry::onOdomInit()
 		rgbdCameras = 0;
 	}
 	keepColor_ = this->declare_parameter("keep_color", keepColor_);
-	std::string rgbdTransport = this->declare_parameter("rgb_transport", std::string("raw"));
+	std::string rgbTransport = this->declare_parameter("rgb_transport", std::string("raw"));
+	if(rgbTransport != "raw") {
+		RCLCPP_WARN(this->get_logger(), "Parameter \"rgb_transport\" has been renamed "
+				"to \"image_transport\" and will be removed "
+				"in future versions! The value (%s) is copied to "
+				"\"image_transport\".", rgbTransport.c_str());
+	}
+	std::string imageTransport = this->declare_parameter("image_transport", rgbTransport);
 	std::string depthTransport = this->declare_parameter("depth_transport", std::string("raw"));
+	
 
 	RCLCPP_INFO(this->get_logger(), "RGBDOdometry: approx_sync    = %s", approxSync?"true":"false");
 	if(approxSync)
@@ -126,7 +134,7 @@ void RGBDOdometry::onOdomInit()
 	RCLCPP_INFO(this->get_logger(), "RGBDOdometry: subscribe_rgbd = %s", subscribeRGBD?"true":"false");
 	RCLCPP_INFO(this->get_logger(), "RGBDOdometry: rgbd_cameras   = %d", rgbdCameras);
 	RCLCPP_INFO(this->get_logger(), "RGBDOdometry: keep_color     = %s", keepColor_?"true":"false");
-	RCLCPP_INFO(this->get_logger(), "RGBDOdometry: rgb_transport   = %s", rgbdTransport.c_str());
+	RCLCPP_INFO(this->get_logger(), "RGBDOdometry: image_transport = %s", imageTransport.c_str());
 	RCLCPP_INFO(this->get_logger(), "RGBDOdometry: depth_transport = %s", depthTransport.c_str());
 
 	rclcpp::SubscriptionOptions options;
@@ -354,18 +362,12 @@ void RGBDOdometry::onOdomInit()
 	}
 	else
 	{
-		image_transport::TransportHints rgb_hints(this, "raw", "rgb_transport");
+		image_transport::TransportHints rgb_hints(this); // using "image_transport" parameter
 		image_transport::TransportHints depth_hints(this, "raw", "depth_transport");
-
-		std::string rgb_topic = get_node_base_interface()->resolve_topic_or_service_name(
-      		"rgb/image", false, false
-		);
-		std::string depth_topic = get_node_base_interface()->resolve_topic_or_service_name(
-      		"depth/image", false, false
-		);
-
-		image_mono_sub_.subscribe(this, rgb_topic, rgb_hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
-		image_depth_sub_.subscribe(this, depth_topic, depth_hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
+		std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		image_mono_sub_.subscribe(this, rgbTopic, rgb_hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
+		image_depth_sub_.subscribe(this, depthTopic, depth_hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
 		info_sub_.subscribe(this, "rgb/camera_info", RCLCPP_QOS(topicQueueSize_, qosCamInfo), options);
 
 		if(approxSync)

--- a/rtabmap_odom/src/nodelets/stereo_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/stereo_odometry.cpp
@@ -109,6 +109,7 @@ void StereoOdometry::onOdomInit()
 	subscribeRGBD = this->declare_parameter("subscribe_rgbd", subscribeRGBD);
 	rgbdCameras = this->declare_parameter("rgbd_cameras", rgbdCameras);
 	keepColor_ = this->declare_parameter("keep_color", keepColor_);
+	std::string imageTransport = this->declare_parameter("image_transport", std::string("raw"));
 
 	RCLCPP_INFO(this->get_logger(), "StereoOdometry: approx_sync = %s", approxSync?"true":"false");
 	if(approxSync)
@@ -119,6 +120,7 @@ void StereoOdometry::onOdomInit()
 	RCLCPP_INFO(this->get_logger(), "StereoOdometry: qos_camera_info = %d", qosCamInfo);
 	RCLCPP_INFO(this->get_logger(), "StereoOdometry: subscribe_rgbd = %s", subscribeRGBD?"true":"false");
 	RCLCPP_INFO(this->get_logger(), "StereoOdometry: keep_color     = %s", keepColor_?"true":"false");
+	RCLCPP_INFO(this->get_logger(), "StereoOdometry: image_transport = %s", imageTransport.c_str());
 
 	rclcpp::SubscriptionOptions options;
 	options.callback_group = dataCallbackGroup_;
@@ -347,9 +349,12 @@ void StereoOdometry::onOdomInit()
 	}
 	else
 	{
-		image_transport::TransportHints hints(this);
-		imageRectLeft_.subscribe(this, "left/image_rect", hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
-		imageRectRight_.subscribe(this, "right/image_rect", hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
+		image_transport::TransportHints hints(this); // using "image_transport" parameter
+		
+		std::string leftTopic = this->get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		std::string rightTopic = this->get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		imageRectLeft_.subscribe(this, leftTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
+		imageRectRight_.subscribe(this, rightTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
 		cameraInfoLeft_.subscribe(this, "left/camera_info", RCLCPP_QOS(topicQueueSize_, qosCamInfo), options);
 		cameraInfoRight_.subscribe(this, "right/camera_info", RCLCPP_QOS(topicQueueSize_, qosCamInfo), options);
 
@@ -373,8 +378,8 @@ void StereoOdometry::onOdomInit()
 				approxSync&&approxSyncMaxInterval!=0.0?uFormat(", max interval=%fs", approxSyncMaxInterval).c_str():"",
 				topicQueueSize_,
 				syncQueueSize_,
-				imageRectLeft_.getTopic().c_str(),
-				imageRectRight_.getTopic().c_str(),
+				imageRectLeft_.getSubscriber().getTopic().c_str(),
+				imageRectRight_.getSubscriber().getTopic().c_str(),
 				cameraInfoLeft_.getSubscriber()->get_topic_name(),
 				cameraInfoRight_.getSubscriber()->get_topic_name());
 	}

--- a/rtabmap_odom/src/nodelets/stereo_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/stereo_odometry.cpp
@@ -351,8 +351,8 @@ void StereoOdometry::onOdomInit()
 	{
 		image_transport::TransportHints hints(this); // using "image_transport" parameter
 		
-		std::string leftTopic = this->get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-		std::string rightTopic = this->get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		std::string leftTopic = this->get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		std::string rightTopic = this->get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 		imageRectLeft_.subscribe(this, leftTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
 		imageRectRight_.subscribe(this, rightTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability((rmw_qos_reliability_policy_t)qos()).get_rmw_qos_profile(), options);
 		cameraInfoLeft_.subscribe(this, "left/camera_info", RCLCPP_QOS(topicQueueSize_, qosCamInfo), options);

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -769,7 +769,7 @@ CoreWrapper::CoreWrapper(const rclcpp::NodeOptions & options) :
 					  Parameters::kRGBDEnabled().c_str());
 		}
 		image_transport::TransportHints hints(this); // using "image_transport" parameter
-		std::string imageTopic = this->get_node_topics_interface()->resolve_topic_name("image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		std::string imageTopic = this->get_node_topics_interface()->resolve_topic_name("image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 		defaultSub_ = image_transport::create_subscription(this, imageTopic, std::bind(&CoreWrapper::defaultCallback, this, std::placeholders::_1), hints.getTransport(), rclcpp::QoS(this->getTopicQueueSize()).reliability((rmw_qos_reliability_policy_t)qosImage_).get_rmw_qos_profile(), subOptions);
 
 

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -768,8 +768,9 @@ CoreWrapper::CoreWrapper(const rclcpp::NodeOptions & options) :
 					  Parameters::kRGBDEnabled().c_str(),
 					  Parameters::kRGBDEnabled().c_str());
 		}
-		image_transport::TransportHints hints(this);
-		defaultSub_ = image_transport::create_subscription(this, "image", std::bind(&CoreWrapper::defaultCallback, this, std::placeholders::_1), hints.getTransport(), rclcpp::QoS(this->getTopicQueueSize()).reliability((rmw_qos_reliability_policy_t)qosImage_).get_rmw_qos_profile(), subOptions);
+		image_transport::TransportHints hints(this); // using "image_transport" parameter
+		std::string imageTopic = this->get_node_topics_interface()->resolve_topic_name("image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+		defaultSub_ = image_transport::create_subscription(this, imageTopic, std::bind(&CoreWrapper::defaultCallback, this, std::placeholders::_1), hints.getTransport(), rclcpp::QoS(this->getTopicQueueSize()).reliability((rmw_qos_reliability_policy_t)qosImage_).get_rmw_qos_profile(), subOptions);
 
 
 		RCLCPP_INFO(this->get_logger(), "\n%s subscribed to:\n   %s", get_name(), defaultSub_.getTopic().c_str());

--- a/rtabmap_sync/include/rtabmap_sync/CommonDataSubscriber.h
+++ b/rtabmap_sync/include/rtabmap_sync/CommonDataSubscriber.h
@@ -269,6 +269,8 @@ private:
 	std::string odomFrameId_;
 	int rgbdCameras_;
 	std::string name_;
+	std::string imageTransport_;
+	std::string depthTransport_;
 
 	rclcpp::CallbackGroup::SharedPtr syncCallbackGroup_;
 

--- a/rtabmap_sync/src/CommonDataSubscriber.cpp
+++ b/rtabmap_sync/src/CommonDataSubscriber.cpp
@@ -47,6 +47,8 @@ CommonDataSubscriber::CommonDataSubscriber(rclcpp::Node & node, bool gui) :
 		subscribedToUserData_(false),
 		odomFrameId_(""),
 		rgbdCameras_(1),
+		imageTransport_("raw"),
+		depthTransport_("raw"),
 
 		// RGB + Depth
 		SYNC_INIT(depth),
@@ -392,6 +394,8 @@ CommonDataSubscriber::CommonDataSubscriber(rclcpp::Node & node, bool gui) :
 				 "\"sync_queue_size\".", syncQueueSize_);
 	}
 	syncQueueSize_ = node.declare_parameter("sync_queue_size", syncQueueSize_);
+	imageTransport_ = node.declare_parameter("image_transport", imageTransport_);
+	depthTransport_ = node.declare_parameter("depth_transport", depthTransport_);
 
 	int qos = node.declare_parameter("qos", (int)RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT);
 	int qosOdom = node.declare_parameter("qos_odom", qos);
@@ -540,6 +544,8 @@ void CommonDataSubscriber::setupCallbacks(
 	RCLCPP_INFO(node.get_logger(), "%s: qos_odom        = %d", name_.c_str(), qosOdom_);
 	RCLCPP_INFO(node.get_logger(), "%s: qos_user_data   = %d", name_.c_str(), qosUserData_);
 	RCLCPP_INFO(node.get_logger(), "%s: approx_sync     = %s", name_.c_str(), approxSync_?"true":"false");
+	RCLCPP_INFO(node.get_logger(), "%s: image_transport = %s", name_.c_str(), imageTransport_.c_str());
+	RCLCPP_INFO(node.get_logger(), "%s: depth_transport = %s", name_.c_str(), depthTransport_.c_str());
 
 	rclcpp::SubscriptionOptions callbackOptions;
 	callbackOptions.callback_group = syncCallbackGroup_;

--- a/rtabmap_sync/src/impl/CommonDataSubscriberDepth.cpp
+++ b/rtabmap_sync/src/impl/CommonDataSubscriberDepth.cpp
@@ -505,8 +505,8 @@ void CommonDataSubscriber::setupDepthCallbacks(
 
 	image_transport::TransportHints rgbHints(&node); // using "image_transport" parameter
 	image_transport::TransportHints depthHints(&node, "raw", "depth_transport");
-	std::string rgbTopic = node.get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-	std::string depthTopic = node.get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rgbTopic = node.get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string depthTopic = node.get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageSub_.subscribe(&node, rgbTopic, rgbHints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	imageDepthSub_.subscribe(&node, depthTopic, depthHints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	cameraInfoSub_.subscribe(&node, "rgb/camera_info", RCLCPP_QOS(topicQueueSize_, qosCameraInfo_), options);

--- a/rtabmap_sync/src/impl/CommonDataSubscriberDepth.cpp
+++ b/rtabmap_sync/src/impl/CommonDataSubscriberDepth.cpp
@@ -503,9 +503,12 @@ void CommonDataSubscriber::setupDepthCallbacks(
 {
 	RCLCPP_INFO(node.get_logger(), "Setup depth callback");
 
-	image_transport::TransportHints hints(&node);
-	imageSub_.subscribe(&node, "rgb/image", hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
-	imageDepthSub_.subscribe(&node, "depth/image", hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
+	image_transport::TransportHints rgbHints(&node); // using "image_transport" parameter
+	image_transport::TransportHints depthHints(&node, "raw", "depth_transport");
+	std::string rgbTopic = node.get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string depthTopic = node.get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	imageSub_.subscribe(&node, rgbTopic, rgbHints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
+	imageDepthSub_.subscribe(&node, depthTopic, depthHints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	cameraInfoSub_.subscribe(&node, "rgb/camera_info", RCLCPP_QOS(topicQueueSize_, qosCameraInfo_), options);
 
 #ifdef RTABMAP_SYNC_USER_DATA

--- a/rtabmap_sync/src/impl/CommonDataSubscriberRGB.cpp
+++ b/rtabmap_sync/src/impl/CommonDataSubscriberRGB.cpp
@@ -503,8 +503,9 @@ void CommonDataSubscriber::setupRGBCallbacks(
 {
 	RCLCPP_INFO(node.get_logger(), "Setup rgb-only callback");
 
-	image_transport::TransportHints hints(&node);
-	imageSub_.subscribe(&node, "rgb/image", hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
+	image_transport::TransportHints hints(&node); // using "image_transport" parameter
+	std::string rgbTopic = node.get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	imageSub_.subscribe(&node, rgbTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	cameraInfoSub_.subscribe(&node, "rgb/camera_info", RCLCPP_QOS(topicQueueSize_, qosCameraInfo_), options);
 
 #ifdef RTABMAP_SYNC_USER_DATA

--- a/rtabmap_sync/src/impl/CommonDataSubscriberRGB.cpp
+++ b/rtabmap_sync/src/impl/CommonDataSubscriberRGB.cpp
@@ -504,7 +504,7 @@ void CommonDataSubscriber::setupRGBCallbacks(
 	RCLCPP_INFO(node.get_logger(), "Setup rgb-only callback");
 
 	image_transport::TransportHints hints(&node); // using "image_transport" parameter
-	std::string rgbTopic = node.get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rgbTopic = node.get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageSub_.subscribe(&node, rgbTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	cameraInfoSub_.subscribe(&node, "rgb/camera_info", RCLCPP_QOS(topicQueueSize_, qosCameraInfo_), options);
 

--- a/rtabmap_sync/src/impl/CommonDataSubscriberStereo.cpp
+++ b/rtabmap_sync/src/impl/CommonDataSubscriberStereo.cpp
@@ -97,9 +97,11 @@ void CommonDataSubscriber::setupStereoCallbacks(
 {
 	RCLCPP_INFO(node.get_logger(), "Setup stereo callback");
 
-	image_transport::TransportHints hints(&node);
-	imageRectLeft_.subscribe(&node, "left/image_rect", hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
-	imageRectRight_.subscribe(&node, "right/image_rect", hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
+	image_transport::TransportHints hints(&node); // using "image_transport" parameter
+	std::string leftTopic = node.get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rightTopic = node.get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	imageRectLeft_.subscribe(&node, leftTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
+	imageRectRight_.subscribe(&node, rightTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	cameraInfoLeft_.subscribe(&node, "left/camera_info", RCLCPP_QOS(topicQueueSize_, qosCameraInfo_), options);
 	cameraInfoRight_.subscribe(&node, "right/camera_info", RCLCPP_QOS(topicQueueSize_, qosCameraInfo_), options);
 

--- a/rtabmap_sync/src/impl/CommonDataSubscriberStereo.cpp
+++ b/rtabmap_sync/src/impl/CommonDataSubscriberStereo.cpp
@@ -98,8 +98,8 @@ void CommonDataSubscriber::setupStereoCallbacks(
 	RCLCPP_INFO(node.get_logger(), "Setup stereo callback");
 
 	image_transport::TransportHints hints(&node); // using "image_transport" parameter
-	std::string leftTopic = node.get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-	std::string rightTopic = node.get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string leftTopic = node.get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rightTopic = node.get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageRectLeft_.subscribe(&node, leftTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	imageRectRight_.subscribe(&node, rightTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize_).reliability(qosImage_).get_rmw_qos_profile(), options);
 	cameraInfoLeft_.subscribe(&node, "left/camera_info", RCLCPP_QOS(topicQueueSize_, qosCameraInfo_), options);

--- a/rtabmap_sync/src/nodelets/rgb_sync.cpp
+++ b/rtabmap_sync/src/nodelets/rgb_sync.cpp
@@ -101,7 +101,7 @@ RGBSync::RGBSync(const rclcpp::NodeOptions & options) :
 	}
 
 	image_transport::TransportHints hints(this); // using "image_transport" parameter
-	std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageSub_.subscribe(this, rgbTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoSub_.subscribe(this, "rgb/camera_info", RCLCPP_QOS(topicQueueSize, qosCaminfo));
 

--- a/rtabmap_sync/src/nodelets/rgbd_sync.cpp
+++ b/rtabmap_sync/src/nodelets/rgbd_sync.cpp
@@ -129,8 +129,8 @@ RGBDSync::RGBDSync(const rclcpp::NodeOptions & options) :
 
 	image_transport::TransportHints rgbHints(this); // using "image_transport" parameter
 	image_transport::TransportHints depthHints(this, "raw", "depth_transport");
-	std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble/Jazzy doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageSub_.subscribe(this, rgbTopic, rgbHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	imageDepthSub_.subscribe(this, depthTopic, depthHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoSub_.subscribe(this, "rgb/camera_info", RCLCPP_QOS(topicQueueSize, qosCamInfo));

--- a/rtabmap_sync/src/nodelets/rgbd_sync.cpp
+++ b/rtabmap_sync/src/nodelets/rgbd_sync.cpp
@@ -76,6 +76,22 @@ RGBDSync::RGBDSync(const rclcpp::NodeOptions & options) :
 	depthScale_ = this->declare_parameter("depth_scale", depthScale_);
 	decimation_ = this->declare_parameter("decimation", decimation_);
 	compressedRate_ = this->declare_parameter("compressed_rate", compressedRate_);
+	std::string rgbImageTransport = this->declare_parameter<std::string>("rgb_image_transport", std::string("raw"));
+	std::string depthImageTransport = this->declare_parameter<std::string>("depth_image_transport", std::string("raw"));
+	if(rgbImageTransport != "raw") {
+		RCLCPP_WARN(this->get_logger(), "Parameter \"rgb_image_transport\" has been renamed "
+				"to \"image_transport\" and will be removed "
+				"in future versions! The value (%s) is copied to "
+				"\"image_transport\".", rgbImageTransport.c_str());
+	}
+	if(depthImageTransport != "raw") {
+		RCLCPP_WARN(this->get_logger(), "Parameter \"depth_image_transport\" has been renamed "
+				"to \"depth_transport\" and will be removed "
+				"in future versions! The value (%s) is copied to "
+				"\"depth_transport\".", depthImageTransport.c_str());
+	}
+	std::string imageTransport = this->declare_parameter("image_transport", rgbImageTransport);
+	std::string depthTransport = this->declare_parameter("depth_transport", depthImageTransport);
 
 	if(decimation_<1)
 	{
@@ -92,6 +108,8 @@ RGBDSync::RGBDSync(const rclcpp::NodeOptions & options) :
 	RCLCPP_INFO(this->get_logger(), "%s: depth_scale = %f", get_name(), depthScale_);
 	RCLCPP_INFO(this->get_logger(), "%s: decimation = %d", get_name(), decimation_);
 	RCLCPP_INFO(this->get_logger(), "%s: compressed_rate = %f", get_name(), compressedRate_);
+	RCLCPP_INFO(this->get_logger(), "%s: image_transport = %s", get_name(), imageTransport.c_str());
+	RCLCPP_INFO(this->get_logger(), "%s: depth_transport = %s", get_name(), depthTransport.c_str());
 
 	rgbdImagePub_ = this->create_publisher<rtabmap_msgs::msg::RGBDImage>("rgbd_image", rclcpp::QoS(1).reliability((rmw_qos_reliability_policy_t)qos));
 	rgbdImageCompressedPub_ = this->create_publisher<rtabmap_msgs::msg::RGBDImage>("rgbd_image/compressed", rclcpp::QoS(1).reliability((rmw_qos_reliability_policy_t)qos));
@@ -109,12 +127,12 @@ RGBDSync::RGBDSync(const rclcpp::NodeOptions & options) :
 		exactSyncDepth_->registerCallback(std::bind(&RGBDSync::callback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	}
 
-  	std::string rgbImageTransport = this->declare_parameter<std::string>("rgb_image_transport", "raw");
-	std::string depthImageTransport = this->declare_parameter<std::string>("depth_image_transport", "raw");
+	image_transport::TransportHints rgbHints(this); // using "image_transport" parameter
+	image_transport::TransportHints depthHints(this, "raw", "depth_transport");
 	std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-	imageSub_.subscribe(this, rgbTopic, rgbImageTransport, rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
-	imageDepthSub_.subscribe(this, depthTopic, depthImageTransport, rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
+	imageSub_.subscribe(this, rgbTopic, rgbHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
+	imageDepthSub_.subscribe(this, depthTopic, depthHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoSub_.subscribe(this, "rgb/camera_info", RCLCPP_QOS(topicQueueSize, qosCamInfo));
 
 	std::string subscribedTopicsMsg = uFormat("\n%s subscribed to (%s sync%s):\n   %s,\n   %s,\n   %s",

--- a/rtabmap_sync/src/nodelets/stereo_sync.cpp
+++ b/rtabmap_sync/src/nodelets/stereo_sync.cpp
@@ -99,8 +99,8 @@ StereoSync::StereoSync(const rclcpp::NodeOptions & options) :
 	}
 
 	image_transport::TransportHints hints(this); // using "image_transport" parameter
-	std::string leftTopic = this->get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-	std::string rightTopic = this->get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string leftTopic = this->get_node_topics_interface()->resolve_topic_name("left/image_rect"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rightTopic = this->get_node_topics_interface()->resolve_topic_name("right/image_rect"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageLeftSub_.subscribe(this, leftTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	imageRightSub_.subscribe(this, rightTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoLeftSub_.subscribe(this, "left/camera_info", RCLCPP_QOS(topicQueueSize, qosCamInfo));

--- a/rtabmap_util/src/nodelets/point_cloud_xyz.cpp
+++ b/rtabmap_util/src/nodelets/point_cloud_xyz.cpp
@@ -158,7 +158,7 @@ PointCloudXYZ::PointCloudXYZ(const rclcpp::NodeOptions & options) :
 	cloudPub_ = create_publisher<sensor_msgs::msg::PointCloud2>("cloud", rclcpp::QoS(1).reliability((rmw_qos_reliability_policy_t)qos));
 
 	image_transport::TransportHints hints(this, "raw", "depth_transport");
-	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageDepthSub_.subscribe(this, depthTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoSub_.subscribe(this, "depth/camera_info", RCLCPP_QOS(topicQueueSize, qosCamInfo));
 

--- a/rtabmap_util/src/nodelets/point_cloud_xyz.cpp
+++ b/rtabmap_util/src/nodelets/point_cloud_xyz.cpp
@@ -97,6 +97,7 @@ PointCloudXYZ::PointCloudXYZ(const rclcpp::NodeOptions & options) :
 	normalRadius_ = this->declare_parameter("normal_radius", normalRadius_);
 	filterNaNs_ = this->declare_parameter("filter_nans", filterNaNs_);
 	roiStr = this->declare_parameter("roi_ratios", roiStr);
+	this->declare_parameter("depth_transport", std::string("raw"));
 
 	//parse roi (region of interest)
 	roiRatios_.resize(4, 0);
@@ -156,8 +157,9 @@ PointCloudXYZ::PointCloudXYZ(const rclcpp::NodeOptions & options) :
 
 	cloudPub_ = create_publisher<sensor_msgs::msg::PointCloud2>("cloud", rclcpp::QoS(1).reliability((rmw_qos_reliability_policy_t)qos));
 
-	image_transport::TransportHints hints(this);
-	imageDepthSub_.subscribe(this, "depth/image", hints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
+	image_transport::TransportHints hints(this, "raw", "depth_transport");
+	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	imageDepthSub_.subscribe(this, depthTopic, hints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoSub_.subscribe(this, "depth/camera_info", RCLCPP_QOS(topicQueueSize, qosCamInfo));
 
 	disparitySub_.subscribe(this, "disparity/image", RCLCPP_QOS(topicQueueSize, qos));

--- a/rtabmap_util/src/nodelets/point_cloud_xyzrgb.cpp
+++ b/rtabmap_util/src/nodelets/point_cloud_xyzrgb.cpp
@@ -188,16 +188,16 @@ PointCloudXYZRGB::PointCloudXYZRGB(const rclcpp::NodeOptions & options) :
 
 	image_transport::TransportHints rgbHints(this); // using "image_transport" parameter
 	image_transport::TransportHints depthHints(this, "raw", "depth_transport");
-	std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rgbTopic = this->get_node_topics_interface()->resolve_topic_name("rgb/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string depthTopic = this->get_node_topics_interface()->resolve_topic_name("depth/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageSub_.subscribe(this, rgbTopic, rgbHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	imageDepthSub_.subscribe(this, depthTopic, depthHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoSub_.subscribe(this, "rgb/camera_info", RCLCPP_QOS(topicQueueSize, qosCamInfo));
 
 	imageDisparitySub_.subscribe(this, "disparity", RCLCPP_QOS(topicQueueSize, qos));
 
-	std::string leftTopic = this->get_node_topics_interface()->resolve_topic_name("left/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
-	std::string rightTopic = this->get_node_topics_interface()->resolve_topic_name("right/image"); // Humble doesn't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string leftTopic = this->get_node_topics_interface()->resolve_topic_name("left/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
+	std::string rightTopic = this->get_node_topics_interface()->resolve_topic_name("right/image"); // Humble/Jazzy don't resolve base topic, fixed by https://github.com/ros-perception/image_common/commit/ea7589ae8c1f7ecb83d6aab7b4c890c2d630d27a
 	imageLeft_.subscribe(this, leftTopic, rgbHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	imageRight_.subscribe(this, rightTopic, rgbHints.getTransport(), rclcpp::QoS(topicQueueSize).reliability((rmw_qos_reliability_policy_t)qos).get_rmw_qos_profile());
 	cameraInfoLeft_.subscribe(this, "left/camera_info", RCLCPP_QOS(topicQueueSize, qosCamInfo));


### PR DESCRIPTION
Unified the way to set `image_transport` and `depth_transport` for all nodes subscribing to image topics with `image_transport` subscribers. We can launch nodes with:
`-p image_transport:="compressed" -p depth_transport:="depthCompressed"` to use respective `image_transport` plugins. 

To make `image_transport` parameter resolvable by `image_transport::TransportHints` is to pre-declare that parameter before creating the hint. 

Examples:
```
ros2 run rtabmap_slam rtabmap -d --ros-args \
   -p image_transport:=compressed \
   -p depth_transport:=compressedDepth
[...]
rtabmap subscribed to (approx sync):
   /odom \
   /rgb/image/compressed \
   /depth/image/compressedDepth \
   /rgb/camera_info
```

```
ros2 run rtabmap_slam rtabmap -d --ros-args \
   -p subscribe_stereo:=true \
   -p image_transport:=compressed
[...]
rtabmap subscribed to (exact sync):
   /odom \
   /left/image_rect/compressed \
   /right/image_rect/compressed \
   /left/camera_info \
   /right/camera_info
```

```
ros2 run rtabmap_odom rgbd_odometry  --ros-args -p image_transport:=compressed -p depth_transport:=compressedDepth
[...]
rgbd_odometry subscribed to (approx sync, topic_queue_size=10, sync_queue_size=5):
   /rgb/image/compressed,
   /depth/image/compressedDepth,
   /rgb/camera_info
```

```
ros2 run rtabmap_odom stereo_odometry  --ros-args -p image_transport:=compressed
[...]
stereo_odometry subscribed to (exact sync, topic_queue_size=10, sync_queue_size=5):
   /left/image_rect/compressed \
   /right/image_rect/compressed \
   /left/camera_info \
   /right/camera_info
```

```
ros2 run rtabmap_sync rgbd_sync --ros-args -p image_transport:=compressed -p depth_transport:=compressedDepth
[...]
rgbd_odometry subscribed to (approx sync, topic_queue_size=10, sync_queue_size=5):
   /rgb/image/compressed,
   /depth/image/compressedDepth,
   /rgb/camera_info
```

```
ros2 run rtabmap_sync rgb_sync --ros-args -p image_transport:=compressed
[...]
rgbd_sync subscribed to (approx sync, max interval=0.000000s):
   /rgb/image/compressed,
   /rgb/camera_info
```

```
ros2 run rtabmap_sync stereo_sync --ros-args -p image_transport:=compressed
[...]
stereo_sync subscribed to (exact sync):
   /left/image_rect/compressed,
   /right/image_rect/compressed,
   /left/camera_info,
   /right/camera_info
```

For backward compatibility:
* `rgbd_odometry` still accepts `rgb_transport` parameter, though a warning will be shown to use `image_transport` instead.
* `rgbd_sync` still accepts `rgb_image_transport` and `depth_image_transport` parameters, though a warning will be shown to use `image_transport` and `depth_transport` parameters respectively.