### PR TITLE
Stale inputs detection

### DIFF
--- a/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
+++ b/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
@@ -278,6 +278,7 @@ private:
 	double landmarkDefaultLinVariance_;
 	bool waitForTransform_;
 	double waitForTransformDuration_;
+	double staleUpdateDetection_;
 	bool useActionForGoal_;
 	bool useSavedMap_;
 	bool genScan_;


### PR DESCRIPTION
The idea is to detect when input data have not been available for a while. For example, the camera driver crashed and had to restart 10 seconds later. Either images or odometry may not be received, so rtabmap's callbacks are not called for a while. If the robot/camera is moved while rtabmap or vo is not aware of it, it could restart at the last known location with last localization covariance.

* Rtabmap: staleness is detected by comparing previous processed data's stamp and new data's stamp. If the duration is higher than the period set by `Rtabmap/DetectionRate` multiplied by `stale_update_detection` parameter, then we trigger a new map automatically. It will act like when we detect odometry is reset.
* Stereo/RGBD/Icp Odometry: staleness is detected by comparing previous processed data's stamp and new data's stamp. If the duration is higher than the period set by `expected_update_rate` multiplied by `stale_update_detection` parameter, then we reset odometry at the last known pose. `