### PR TITLE
ros1: Migrating tf to tf2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,9 +23,16 @@
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/catkin_ws/src/rtabmap_ros,type=bind",
     "workspaceFolder": "/home/vscode/catkin_ws",
     "postCreateCommand": "cd /home/vscode/catkin_ws/src && catkin_init_workspace",
+    "hostRequirements": {
+        "gpu": "optional"
+    },
     "runArgs": ["--privileged",
-                "--runtime=nvidia",
+                "--gpus=all",
+                //"--runtime=nvidia", // uncommment this if rtabmap doesn't show up in nvidia-smi on the host computer
                 "--env=DISPLAY",
                 "--env=QT_X11_NO_MITSHM=1",
-                "--volume=/tmp/.X11-unix:/tmp/.X11-unix"]
+                "--volume=/tmp/.X11-unix:/tmp/.X11-unix"],
+    "containerEnv": {
+        "NVIDIA_VISIBLE_DEVICES": "all"
+    }
 }

--- a/.github/workflows/noetic-pr.yml
+++ b/.github/workflows/noetic-pr.yml
@@ -1,0 +1,41 @@
+name: noetic-pr
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        docker_tag: [rtabmap_ros_noetic_pr]
+        include:
+        - docker_tag: rtabmap_ros_noetic_pr
+          docker_path: 'noetic/latest'
+          docker_platforms: |
+            linux/amd64
+    
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          platforms: ${{ matrix.docker_platforms }}
+          file: ./docker/${{ matrix.docker_path }}/Dockerfile
+          tags: ${{ matrix.docker_tag }}
+

--- a/rtabmap_conversions/CMakeLists.txt
+++ b/rtabmap_conversions/CMakeLists.txt
@@ -3,7 +3,7 @@ project(rtabmap_conversions)
 
 find_package(catkin REQUIRED COMPONENTS
              cv_bridge roscpp sensor_msgs std_msgs geometry_msgs
-             tf tf_conversions eigen_conversions laser_geometry pcl_conversions 
+             tf tf2_ros tf_conversions eigen_conversions laser_geometry pcl_conversions
              image_geometry rtabmap_msgs
 )
 
@@ -13,7 +13,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES rtabmap_conversions
   CATKIN_DEPENDS cv_bridge roscpp sensor_msgs std_msgs geometry_msgs
-             tf tf_conversions eigen_conversions laser_geometry pcl_conversions 
+             tf tf2_ros tf_conversions eigen_conversions laser_geometry pcl_conversions
              image_geometry rtabmap_msgs
   DEPENDS RTABMap
 )

--- a/rtabmap_conversions/include/rtabmap_conversions/MsgConversion.h
+++ b/rtabmap_conversions/include/rtabmap_conversions/MsgConversion.h
@@ -29,7 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MSGCONVERSION_H_
 
 #include <tf/tf.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <geometry_msgs/Transform.h>
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
@@ -135,7 +136,7 @@ rtabmap::StereoCameraModel stereoCameraModelFromROS(
 		const sensor_msgs::CameraInfo & leftCamInfo,
 		const sensor_msgs::CameraInfo & rightCamInfo,
 		const std::string & frameId,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform);
 
 void mapDataFromROS(
@@ -190,7 +191,7 @@ rtabmap::Landmarks landmarksFromROS(
 		const std::string & frameId,
 		const std::string & odomFrameId,
 		const ros::Time & odomStamp,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		double defaultLinVariance,
 		double defaultAngVariance);
@@ -202,7 +203,7 @@ rtabmap::Transform getTransform(
 		const std::string & fromFrameId,
 		const std::string & toFrameId,
 		const ros::Time & stamp,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform);
 
 
@@ -213,7 +214,7 @@ rtabmap::Transform getMovingTransform(
 		const std::string & fixedFrame,
 		const ros::Time & stampFrom,
 		const ros::Time & stampTo,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform);
 
 bool convertRGBDMsgs(
@@ -228,7 +229,7 @@ bool convertRGBDMsgs(
 		cv::Mat & depth,
 		std::vector<rtabmap::CameraModel> & cameraModels,
 		std::vector<rtabmap::StereoCameraModel> & stereoCameraModels,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool alreadRectifiedImages,
 		const std::vector<std::vector<rtabmap_msgs::KeyPoint> > & localKeyPointsMsgs = std::vector<std::vector<rtabmap_msgs::KeyPoint> >(),
@@ -249,7 +250,7 @@ bool convertStereoMsg(
 		cv::Mat & left,
 		cv::Mat & right,
 		rtabmap::StereoCameraModel & stereoModel,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool alreadyRectified);
 
@@ -259,7 +260,7 @@ bool convertScanMsg(
 		const std::string & odomFrameId,
 		const ros::Time & odomStamp,
 		rtabmap::LaserScan & scan,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool outputInFrameId = false);
 
@@ -269,7 +270,7 @@ bool convertScan3dMsg(
 		const std::string & odomFrameId,
 		const ros::Time & odomStamp,
 		rtabmap::LaserScan & scan,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		int maxPoints = 0,
 		float maxRange = 0.0f,
@@ -279,7 +280,7 @@ bool deskew(
 		const sensor_msgs::PointCloud2 & input,
 		sensor_msgs::PointCloud2 & output,
 		const std::string & fixedFrameId,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool slerp = false);
 

--- a/rtabmap_conversions/package.xml
+++ b/rtabmap_conversions/package.xml
@@ -23,6 +23,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf</depend>
+  <depend>tf2_ros</depend>
   <depend>tf_conversions</depend>
 
 </package>

--- a/rtabmap_conversions/src/MsgConversion.cpp
+++ b/rtabmap_conversions/src/MsgConversion.cpp
@@ -928,14 +928,14 @@ rtabmap::StereoCameraModel stereoCameraModelFromROS(
 		const sensor_msgs::CameraInfo & leftCamInfo,
 		const sensor_msgs::CameraInfo & rightCamInfo,
 		const std::string & frameId,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform)
 {
 	rtabmap::Transform localTransform = getTransform(
 			frameId,
 			leftCamInfo.header.frame_id,
 			leftCamInfo.header.stamp,
-			listener,
+			tfBuffer,
 			waitForTransform);
 	if(localTransform.isNull())
 	{
@@ -946,7 +946,7 @@ rtabmap::StereoCameraModel stereoCameraModelFromROS(
 			leftCamInfo.header.frame_id,
 			rightCamInfo.header.frame_id,
 			leftCamInfo.header.stamp,
-			listener,
+			tfBuffer,
 			waitForTransform);
 	if(stereoTransform.isNull())
 	{
@@ -1885,7 +1885,7 @@ rtabmap::Landmarks landmarksFromROS(
 		const std::string & frameId,
 		const std::string & odomFrameId,
 		const ros::Time & odomStamp,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		double defaultLinVariance,
 		double defaultAngVariance)
@@ -1903,7 +1903,7 @@ rtabmap::Landmarks landmarksFromROS(
 				frameId,
 				iter->second.first.header.frame_id,
 				iter->second.first.header.stamp,
-				listener,
+				tfBuffer,
 				waitForTransform);
 
 		if(baseToCamera.isNull())
@@ -1923,7 +1923,7 @@ rtabmap::Landmarks landmarksFromROS(
 					odomFrameId,
 					odomStamp,
 					iter->second.first.header.stamp,
-					listener,
+					tfBuffer,
 					waitForTransform);
 			if(!correction.isNull())
 			{
@@ -1952,32 +1952,20 @@ rtabmap::Transform getTransform(
 		const std::string & fromFrameId,
 		const std::string & toFrameId,
 		const ros::Time & stamp,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform)
 {
 	// TF ready?
 	rtabmap::Transform transform;
 	try
 	{
-		if(waitForTransform > 0.0 && !stamp.isZero())
-		{
-			//if(!tfBuffer_.canTransform(fromFrameId, toFrameId, stamp, ros::Duration(1)))
-			std::string errorMsg;
-			if(!listener.waitForTransform(fromFrameId, toFrameId, stamp, ros::Duration(waitForTransform), ros::Duration(0.01), &errorMsg))
-			{
-				ROS_WARN("Could not get transform from %s to %s after %f seconds (for stamp=%f)! Error=\"%s\".",
-						fromFrameId.c_str(), toFrameId.c_str(), waitForTransform, stamp.toSec(), errorMsg.c_str());
-				return transform;
-			}
-		}
-
-		tf::StampedTransform tmp;
-		listener.lookupTransform(fromFrameId, toFrameId, stamp, tmp);
-		transform = rtabmap_conversions::transformFromTF(tmp);
+		geometry_msgs::TransformStamped tmp;
+		tmp = tfBuffer.lookupTransform(fromFrameId, toFrameId, stamp, ros::Duration(waitForTransform));
+		transform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 	}
-	catch(tf::TransformException & ex)
+	catch(tf2::TransformException & ex)
 	{
-		ROS_WARN("(getting transform %s -> %s) %s", fromFrameId.c_str(), toFrameId.c_str(), ex.what());
+		ROS_WARN("(getting transform %s -> %s) %s (wait_for_transform=%f)", fromFrameId.c_str(), toFrameId.c_str(), ex.what(), waitForTransform);
 	}
 	return transform;
 }
@@ -1989,30 +1977,18 @@ rtabmap::Transform getMovingTransform(
 		const std::string & fixedFrame,
 		const ros::Time & stampFrom,
 		const ros::Time & stampTo,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform)
 {
 	// TF ready?
 	rtabmap::Transform transform;
 	try
 	{
-		ros::Time stamp = stampTo>stampFrom?stampTo:stampFrom;
-		if(waitForTransform > 0.0 && !stamp.isZero())
-		{
-			std::string errorMsg;
-			if(!listener.waitForTransform(movingFrame, fixedFrame, stamp, ros::Duration(waitForTransform), ros::Duration(0.01), &errorMsg))
-			{
-				ROS_WARN("Could not get transform from %s to %s accordingly to %s after %f seconds (for stamps=%f -> %f)! Error=\"%s\".",
-						movingFrame.c_str(), movingFrame.c_str(), fixedFrame.c_str(), waitForTransform, stampTo.toSec(), stampFrom.toSec(), errorMsg.c_str());
-				return transform;
-			}
-		}
-
-		tf::StampedTransform tmp;
-		listener.lookupTransform(movingFrame, stampFrom, movingFrame, stampTo, fixedFrame, tmp);
-		transform = rtabmap_conversions::transformFromTF(tmp);
+		geometry_msgs::TransformStamped tmp;
+		tmp = tfBuffer.lookupTransform(movingFrame, stampFrom, movingFrame, stampTo, fixedFrame, ros::Duration(waitForTransform));
+		transform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 	}
-	catch(tf::TransformException & ex)
+	catch(tf2::TransformException & ex)
 	{
 		ROS_WARN("(getting transform movement of %s according to fixed %s) %s", movingFrame.c_str(), fixedFrame.c_str(), ex.what());
 	}
@@ -2031,7 +2007,7 @@ bool convertRGBDMsgs(
 		cv::Mat & depth,
 		std::vector<rtabmap::CameraModel> & cameraModels,
 		std::vector<rtabmap::StereoCameraModel> & stereoCameraModels,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool alreadRectifiedImages,
 		const std::vector<std::vector<rtabmap_msgs::KeyPoint> > & localKeyPointsMsgs,
@@ -2157,7 +2133,7 @@ bool convertRGBDMsgs(
 		}
 
 		// use depth's stamp so that geometry is sync to odom, use rgb frame as we assume depth is registered (normally depth msg should have same frame than rgb)
-		rtabmap::Transform localTransform = rtabmap_conversions::getTransform(frameId, !imageMsgs.empty()?imageMsgs[i]->header.frame_id:cameraInfoMsgs[i].header.frame_id, stamp, listener, waitForTransform);
+		rtabmap::Transform localTransform = rtabmap_conversions::getTransform(frameId, !imageMsgs.empty()?imageMsgs[i]->header.frame_id:cameraInfoMsgs[i].header.frame_id, stamp, tfBuffer, waitForTransform);
 		if(localTransform.isNull())
 		{
 			ROS_ERROR("TF of received image %d at time %fs is not set!", i, stamp.toSec());
@@ -2171,7 +2147,7 @@ bool convertRGBDMsgs(
 					odomFrameId,
 					odomStamp,
 					stamp,
-					listener,
+					tfBuffer,
 					waitForTransform);
 			if(sensorT.isNull())
 			{
@@ -2310,7 +2286,7 @@ bool convertRGBDMsgs(
 							depthCameraInfoMsgs[i].header.frame_id,
 							cameraInfoMsgs[i].header.frame_id,
 							cameraInfoMsgs[i].header.stamp,
-							listener,
+							tfBuffer,
 							waitForTransform);
 					if(stereoTransform.isNull())
 					{
@@ -2355,7 +2331,7 @@ bool convertRGBDMsgs(
 						cameraInfoMsgs[i].header.frame_id,
 						depthCameraInfoMsgs[i].header.frame_id,
 						cameraInfoMsgs[i].header.stamp,
-						listener,
+						tfBuffer,
 						waitForTransform);
 				}
 				if(stereoTransform.isNull() || stereoTransform.x()<=0)
@@ -2423,7 +2399,7 @@ bool convertStereoMsg(
 		cv::Mat & left,
 		cv::Mat & right,
 		rtabmap::StereoCameraModel & stereoModel,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool alreadyRectified)
 {
@@ -2474,7 +2450,7 @@ bool convertStereoMsg(
 		right = cv_bridge::cvtColor(rightImageMsg, "mono8")->image;
 	}
 
-	rtabmap::Transform localTransform = getTransform(frameId, leftImageMsg->header.frame_id, leftImageMsg->header.stamp, listener, waitForTransform);
+	rtabmap::Transform localTransform = getTransform(frameId, leftImageMsg->header.frame_id, leftImageMsg->header.stamp, tfBuffer, waitForTransform);
 	if(localTransform.isNull())
 	{
 		return false;
@@ -2487,7 +2463,7 @@ bool convertStereoMsg(
 				odomFrameId,
 				odomStamp,
 				leftImageMsg->header.stamp,
-				listener,
+				tfBuffer,
 				waitForTransform);
 		if(sensorT.isNull())
 		{
@@ -2507,7 +2483,7 @@ bool convertStereoMsg(
 				rightCamInfoMsg.header.frame_id,
 				leftCamInfoMsg.header.frame_id,
 				leftCamInfoMsg.header.stamp,
-				listener,
+				tfBuffer,
 				waitForTransform);
 		if(stereoTransform.isNull())
 		{
@@ -2537,7 +2513,7 @@ bool convertStereoMsg(
 				leftCamInfoMsg.header.frame_id,
 				rightCamInfoMsg.header.frame_id,
 				leftCamInfoMsg.header.stamp,
-				listener,
+				tfBuffer,
 				waitForTransform);
 		if(stereoTransform.isNull() || stereoTransform.x()<=0)
 		{
@@ -2575,7 +2551,7 @@ bool convertScanMsg(
 		const std::string & odomFrameId,
 		const ros::Time & odomStamp,
 		rtabmap::LaserScan & scan,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool outputInFrameId)
 {
@@ -2603,7 +2579,7 @@ bool convertScanMsg(
 			odomFrameId.empty()?frameId:odomFrameId,
 			scan2dMsg.header.stamp,
 			scan2dMsg.header.stamp + ros::Duration().fromSec(scan2dMsg.ranges.size()*scan2dMsg.time_increment),
-			listener,
+			tfBuffer,
 			waitForTransform);
 	if(tmpT.isNull())
 	{
@@ -2614,7 +2590,7 @@ bool convertScanMsg(
 			frameId,
 			scan2dMsg.header.frame_id,
 			scan2dMsg.header.stamp,
-			listener,
+			tfBuffer,
 			waitForTransform);
 	if(scanLocalTransform.isNull())
 	{
@@ -2624,14 +2600,14 @@ bool convertScanMsg(
 	//transform in frameId_ frame
 	sensor_msgs::PointCloud2 scanOut;
 	laser_geometry::LaserProjection projection;
-	projection.transformLaserScanToPointCloud(odomFrameId.empty()?frameId:odomFrameId, scan2dMsg, scanOut, listener);
+	projection.transformLaserScanToPointCloud(odomFrameId.empty()?frameId:odomFrameId, scan2dMsg, scanOut, tfBuffer);
 
 	//transform back in laser frame
 	rtabmap::Transform laserToOdom = getTransform(
 			scan2dMsg.header.frame_id,
 			odomFrameId.empty()?frameId:odomFrameId,
 			scan2dMsg.header.stamp,
-			listener,
+			tfBuffer,
 			waitForTransform);
 	if(laserToOdom.isNull())
 	{
@@ -2646,7 +2622,7 @@ bool convertScanMsg(
 				odomFrameId,
 				odomStamp,
 				scan2dMsg.header.stamp,
-				listener,
+				tfBuffer,
 				waitForTransform);
 		if(sensorT.isNull())
 		{
@@ -2734,7 +2710,7 @@ bool convertScan3dMsg(
 		const std::string & odomFrameId,
 		const ros::Time & odomStamp,
 		rtabmap::LaserScan & scan,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		int maxPoints,
 		float maxRange,
@@ -2743,7 +2719,7 @@ bool convertScan3dMsg(
 	UASSERT_MSG(scan3dMsg.data.size() == scan3dMsg.row_step*scan3dMsg.height,
 			uFormat("data=%d row_step=%d height=%d", scan3dMsg.data.size(), scan3dMsg.row_step, scan3dMsg.height).c_str());
 
-	rtabmap::Transform scanLocalTransform = getTransform(frameId, scan3dMsg.header.frame_id, scan3dMsg.header.stamp, listener, waitForTransform);
+	rtabmap::Transform scanLocalTransform = getTransform(frameId, scan3dMsg.header.frame_id, scan3dMsg.header.stamp, tfBuffer, waitForTransform);
 	if(scanLocalTransform.isNull())
 	{
 		ROS_ERROR("TF of received scan cloud at time %fs is not set, aborting rtabmap update.", scan3dMsg.header.stamp.toSec());
@@ -2758,7 +2734,7 @@ bool convertScan3dMsg(
 				odomFrameId,
 				odomStamp,
 				scan3dMsg.header.stamp,
-				listener,
+				tfBuffer,
 				waitForTransform);
 		if(sensorT.isNull())
 		{
@@ -2779,13 +2755,13 @@ bool deskew_impl(
 		const sensor_msgs::PointCloud2 & input,
 		sensor_msgs::PointCloud2 & output,
 		const std::string & fixedFrameId,
-		tf::TransformListener * listener,
+		tf2_ros::Buffer * tfBuffer,
 		double waitForTransform,
 		bool slerp,
 		const rtabmap::Transform & velocity,
 		double previousStamp)
 {
-	if(listener != 0)
+	if(tfBuffer != 0)
 	{
 		if(input.header.frame_id.empty())
 		{
@@ -3088,16 +3064,15 @@ bool deskew_impl(
 	}
 
 	std::string errorMsg;
-	if(listener != 0 &&
+	if(tfBuffer != 0 &&
 	   waitForTransform>0.0 &&
-	   !listener->waitForTransform(
+	   !tfBuffer->canTransform(
 			input.header.frame_id,
 			firstStamp,
 			input.header.frame_id,
 			lastStamp,
 			fixedFrameId,
 			ros::Duration(waitForTransform),
-			ros::Duration(0.01),
 			&errorMsg))
 	{
 		ROS_ERROR("Could not estimate motion of %s accordingly to fixed frame %s between stamps %f and %f! (%s)",
@@ -3114,21 +3089,21 @@ bool deskew_impl(
 	double scanTime = 0;
 	if(slerp)
 	{
-		if(listener != 0)
+		if(tfBuffer != 0)
 		{
 			firstPose = rtabmap_conversions::getMovingTransform(
 					input.header.frame_id,
 					fixedFrameId,
 					input.header.stamp,
 					firstStamp,
-					*listener,
+					*tfBuffer,
 					0);
 			lastPose = rtabmap_conversions::getMovingTransform(
 					input.header.frame_id,
 					fixedFrameId,
 					input.header.stamp,
 					lastStamp,
-					*listener,
+					*tfBuffer,
 					0);
 		}
 		else
@@ -3233,7 +3208,7 @@ bool deskew_impl(
 						fixedFrameId,
 						output.header.stamp,
 						stamp,
-						*listener,
+						*tfBuffer,
 						0);
 				if(transform.isNull())
 				{
@@ -3327,7 +3302,7 @@ bool deskew_impl(
 						fixedFrameId,
 						output.header.stamp,
 						stamp,
-						*listener,
+						*tfBuffer,
 						0);
 				if(transform.isNull())
 				{
@@ -3376,11 +3351,11 @@ bool deskew(
 		const sensor_msgs::PointCloud2 & input,
 		sensor_msgs::PointCloud2 & output,
 		const std::string & fixedFrameId,
-		tf::TransformListener & listener,
+		tf2_ros::Buffer & tfBuffer,
 		double waitForTransform,
 		bool slerp)
 {
-	return deskew_impl(input, output, fixedFrameId, &listener, waitForTransform, slerp, rtabmap::Transform(), 0);
+	return deskew_impl(input, output, fixedFrameId, &tfBuffer, waitForTransform, slerp, rtabmap::Transform(), 0);
 }
 
 bool deskew(

--- a/rtabmap_conversions/src/MsgConversion.cpp
+++ b/rtabmap_conversions/src/MsgConversion.cpp
@@ -1960,7 +1960,11 @@ rtabmap::Transform getTransform(
 	try
 	{
 		geometry_msgs::TransformStamped tmp;
-		tmp = tfBuffer.lookupTransform(fromFrameId, toFrameId, stamp, ros::Duration(waitForTransform));
+		tmp = tfBuffer.lookupTransform(
+			!fromFrameId.empty()&&fromFrameId.at(0)=='/'?fromFrameId.substr(1):fromFrameId,
+			!toFrameId.empty()&&toFrameId.at(0)=='/'?toFrameId.substr(1):toFrameId,
+			stamp,
+			ros::Duration(waitForTransform));
 		transform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 	}
 	catch(tf2::TransformException & ex)
@@ -1985,7 +1989,13 @@ rtabmap::Transform getMovingTransform(
 	try
 	{
 		geometry_msgs::TransformStamped tmp;
-		tmp = tfBuffer.lookupTransform(movingFrame, stampFrom, movingFrame, stampTo, fixedFrame, ros::Duration(waitForTransform));
+		tmp = tfBuffer.lookupTransform(
+			!movingFrame.empty()&&movingFrame.at(0)=='/'?movingFrame.substr(1):movingFrame,
+			stampFrom,
+			!movingFrame.empty()&&movingFrame.at(0)=='/'?movingFrame.substr(1):movingFrame,
+			stampTo,
+			!fixedFrame.empty()&&fixedFrame.at(0)=='/'?fixedFrame.substr(1):fixedFrame,
+			ros::Duration(waitForTransform));
 		transform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 	}
 	catch(tf2::TransformException & ex)
@@ -3067,11 +3077,11 @@ bool deskew_impl(
 	if(tfBuffer != 0 &&
 	   waitForTransform>0.0 &&
 	   !tfBuffer->canTransform(
-			input.header.frame_id,
+			!input.header.frame_id.empty()&&input.header.frame_id.at(0)=='/'?input.header.frame_id.substr(1):input.header.frame_id,
 			firstStamp,
-			input.header.frame_id,
+			!input.header.frame_id.empty()&&input.header.frame_id.at(0)=='/'?input.header.frame_id.substr(1):input.header.frame_id,
 			lastStamp,
-			fixedFrameId,
+			!fixedFrameId.empty()&&fixedFrameId.at(0)=='/'?fixedFrameId.substr(1):fixedFrameId,
 			ros::Duration(waitForTransform),
 			&errorMsg))
 	{

--- a/rtabmap_costmap_plugins/src/voxel_layer.cpp
+++ b/rtabmap_costmap_plugins/src/voxel_layer.cpp
@@ -406,7 +406,10 @@ void VoxelLayer::updateOrigin(double new_origin_x, double new_origin_y)
   {
       geometry_msgs::TransformStamped transformStamped;
 #ifdef COSTMAP_2D_POINTCLOUD2
-      transformStamped = tf_->lookupTransform(global_frame_, robot_base_frame_, ros::Time(0));
+      transformStamped = tf_->lookupTransform(
+          !global_frame_.empty()&&global_frame_.at(0)=='/'?global_frame_.substr(1):global_frame_,
+          !robot_base_frame_.empty()&&robot_base_frame_.at(0)=='/'?robot_base_frame_.substr(1):robot_base_frame_,
+          ros::Time(0));
 #else
       tf::StampedTransform stampedTransform;
       tf_->lookupTransform(global_frame_, robot_base_frame_, ros::Time(0), stampedTransform);

--- a/rtabmap_demos/launch/demo_turtlebot3_navigation.launch
+++ b/rtabmap_demos/launch/demo_turtlebot3_navigation.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <launch>
   <!--
-    $ sudo apt install ros-melodic-turtlebot3* ros-melodic-dwa-local-planner
+    $ sudo apt install ros-$ROS_DISTRO-turtlebot3* ros-$ROS_DISTRO-dwa-local-planner
     To avoid TF warning about leading '/' in frame name, remove it in:
-       - "/opt/ros/melodic/share/turtlebot3_navigation/param/global_costmap_params.yaml"
-       - "/opt/ros/melodic/share/turtlebot3_navigation/param/local_costmap_params.yaml"
+       - "/opt/ros/$ROS_DISTRO/share/turtlebot3_navigation/param/global_costmap_params.yaml"
+       - "/opt/ros/$ROS_DISTRO/share/turtlebot3_navigation/param/local_costmap_params.yaml"
 
     Example Gazebo:
     $ export TURTLEBOT3_MODEL=waffle

--- a/rtabmap_demos/src/SaveObjectsExample.cpp
+++ b/rtabmap_demos/src/SaveObjectsExample.cpp
@@ -71,7 +71,10 @@ public:
                 geometry_msgs::TransformStamped pose;
                 try
                 {
-                    pose = tfBuffer_.lookupTransform(frameId_, objectFrameId, msg->header.stamp);
+                    pose = tfBuffer_.lookupTransform(
+                            !frameId_.empty()&&frameId_.at(0)=='/'?frameId_.substr(1):frameId_,
+                            !objectFrameId.empty()&&objectFrameId.at(0)=='/'?objectFrameId.substr(1):objectFrameId,
+                            msg->header.stamp);
                 }
                 catch(tf2::TransformException & ex)
                 {

--- a/rtabmap_demos/src/SaveObjectsExample.cpp
+++ b/rtabmap_demos/src/SaveObjectsExample.cpp
@@ -26,7 +26,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <ros/ros.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <find_object_2d/ObjectsStamped.h>
 #include <rtabmap/utilite/UConversion.h>
 #include <opencv2/core/core.hpp>
@@ -40,6 +41,7 @@ class SaveObjectsExample
 public:
 	SaveObjectsExample() :
         objFramePrefix_("object"),
+        tfListener_(tfBuffer_),
         frameId_("base_link")
     {
         ros::NodeHandle pnh("~");
@@ -66,12 +68,12 @@ public:
                 std::string objectFrameId = uFormat("%s_%d", objFramePrefix_.c_str(),id); // "object_1", "object_2"
 
                 // get pose of the object in base frame
-                tf::StampedTransform pose;
+                geometry_msgs::TransformStamped pose;
                 try
                 {
-                    tfListener_.lookupTransform(frameId_, objectFrameId, msg->header.stamp, pose);
+                    pose = tfBuffer_.lookupTransform(frameId_, objectFrameId, msg->header.stamp);
                 }
-                catch(tf::TransformException & ex)
+                catch(tf2::TransformException & ex)
                 {
                     ROS_WARN("%s",ex.what());
                     return;
@@ -79,13 +81,13 @@ public:
 
                 data.at<double>(i, 0) = double(id);
                 data.at<double>(i, 1) = ros::Time(msg->header.stamp).toSec();
-                data.at<double>(i, 2) = pose.getOrigin().x();
-                data.at<double>(i, 3) = pose.getOrigin().y();
-                data.at<double>(i, 4) = pose.getOrigin().z();
-                data.at<double>(i, 5) = pose.getRotation().x();
-                data.at<double>(i, 6) = pose.getRotation().y();
-                data.at<double>(i, 7) = pose.getRotation().z();
-                data.at<double>(i, 8) = pose.getRotation().w();
+                data.at<double>(i, 2) = pose.transform.translation.x;
+                data.at<double>(i, 3) = pose.transform.translation.y;
+                data.at<double>(i, 4) = pose.transform.translation.z;
+                data.at<double>(i, 5) = pose.transform.rotation.x;
+                data.at<double>(i, 6) = pose.transform.rotation.y;
+                data.at<double>(i, 7) = pose.transform.rotation.z;
+                data.at<double>(i, 8) = pose.transform.rotation.w;
             }
 
             rtabmap_msgs::UserData dataMsg;
@@ -254,7 +256,8 @@ private:
     std::string objFramePrefix_;
     ros::Subscriber subObjects_;
     ros::Subscriber subsMapData_;
-    tf::TransformListener tfListener_;
+    tf2_ros::Buffer tfBuffer_;
+    tf2_ros::TransformListener tfListener_;
     ros::Publisher pub_;
     ros::Publisher pubMarkers_;
     std::map<int, cv::Mat> nodeToObjects_;

--- a/rtabmap_legacy/src/nodelets/obstacles_detection_old.cpp
+++ b/rtabmap_legacy/src/nodelets/obstacles_detection_old.cpp
@@ -123,7 +123,11 @@ private:
 		try
 		{
 			geometry_msgs::TransformStamped tmp;
-			tmp = tfBuffer_.lookupTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, ros::Duration(waitForTransform_?1.0:0.0));
+			tmp = tfBuffer_.lookupTransform(
+					!frameId_.empty()&&frameId_.at(0)=='/'?frameId_.substr(1):frameId_,
+					!cloudMsg->header.frame_id.empty()&&cloudMsg->header.frame_id.at(0)=='/'?cloudMsg->header.frame_id.substr(1):cloudMsg->header.frame_id,
+					cloudMsg->header.stamp,
+					ros::Duration(waitForTransform_?1.0:0.0));
 			localTransform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 		}
 		catch(tf2::TransformException & ex)

--- a/rtabmap_legacy/src/nodelets/obstacles_detection_old.cpp
+++ b/rtabmap_legacy/src/nodelets/obstacles_detection_old.cpp
@@ -33,7 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <sensor_msgs/PointCloud2.h>
 
@@ -61,7 +62,8 @@ public:
 		segmentFlatObstacles_(false),
 		waitForTransform_(false),
 		optimizeForCloseObjects_(false),
-		projVoxelSize_(0.01)
+		projVoxelSize_(0.01),
+		tfListener_(tfBuffer_)
 	{}
 
 	virtual ~ObstaclesDetectionOld()
@@ -120,19 +122,11 @@ private:
 		rtabmap::Transform localTransform;
 		try
 		{
-			if(waitForTransform_)
-			{
-				if(!tfListener_.waitForTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, ros::Duration(1)))
-				{
-					NODELET_ERROR("Could not get transform from %s to %s after 1 second!", frameId_.c_str(), cloudMsg->header.frame_id.c_str());
-					return;
-				}
-			}
-			tf::StampedTransform tmp;
-			tfListener_.lookupTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, tmp);
-			localTransform = rtabmap_conversions::transformFromTF(tmp);
+			geometry_msgs::TransformStamped tmp;
+			tmp = tfBuffer_.lookupTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, ros::Duration(waitForTransform_?1.0:0.0));
+			localTransform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 		}
-		catch(tf::TransformException & ex)
+		catch(tf2::TransformException & ex)
 		{
 			NODELET_ERROR("%s",ex.what());
 			return;
@@ -342,7 +336,8 @@ private:
 	bool optimizeForCloseObjects_;
 	double projVoxelSize_;
 
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 
 	ros::Publisher groundPub_;
 	ros::Publisher obstaclesPub_;

--- a/rtabmap_odom/include/rtabmap_odom/OdometryROS.h
+++ b/rtabmap_odom/include/rtabmap_odom/OdometryROS.h
@@ -31,8 +31,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ros/ros.h>
 #include <nodelet/nodelet.h>
 
+#include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_broadcaster.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <std_srvs/Empty.h>
 #include <std_msgs/Header.h>
@@ -84,7 +85,7 @@ protected:
 	void initDiagnosticMsg(const std::string & subscribedTopicsMsg, bool approxSync, const std::string & subscribedTopic = "");
 
 	virtual void flushCallbacks() = 0;
-	tf::TransformListener & tfListener() {return tfListener_;}
+	tf2_ros::Buffer & tfBuffer() {return tfBuffer_;}
 	double waitForTransformDuration() const {return waitForTransform_?waitForTransformDuration_:0.0;}
 	rtabmap::Transform velocityGuess() const;
 	ros::Time previousStamp() const {return previousStamp_;}
@@ -142,7 +143,8 @@ private:
 	ros::ServiceServer setLogWarnSrv_;
 	ros::ServiceServer setLogErrorSrv_;
 	tf2_ros::TransformBroadcaster tfBroadcaster_;
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 	ros::Subscriber imuSub_;
 
 	// Safe-threading

--- a/rtabmap_odom/src/OdometryROS.cpp
+++ b/rtabmap_odom/src/OdometryROS.cpp
@@ -74,6 +74,7 @@ OdometryROS::OdometryROS(bool stereoParams, bool visParams, bool icpParams) :
 	waitForTransformDuration_(0.1), // 100 ms
 	publishNullWhenLost_(true),
 	publishCompressedSensorData_(false),
+	tfListener_(tfBuffer_),
 	paused_(false),
 	resetCountdown_(0),
 	resetCurrentCount_(0),
@@ -429,7 +430,7 @@ void OdometryROS::callbackIMU(const sensor_msgs::ImuConstPtr& msg)
 		rtabmap::Transform localTransform = rtabmap::Transform::getIdentity();
 		if(this->frameId().compare(msg->header.frame_id) != 0)
 		{
-			localTransform = rtabmap_conversions::getTransform(this->frameId(), msg->header.frame_id, msg->header.stamp, this->tfListener(), this->waitForTransformDuration());
+			localTransform = rtabmap_conversions::getTransform(this->frameId(), msg->header.frame_id, msg->header.stamp, this->tfBuffer(), this->waitForTransformDuration());
 		}
 		if(localTransform.isNull())
 		{
@@ -647,7 +648,7 @@ void OdometryROS::processData()
 
 		if(!groundTruthFrameId_.empty())
 		{
-			groundTruth = rtabmap_conversions::getTransform(groundTruthFrameId_, groundTruthBaseFrameId_, header.stamp, this->tfListener(), this->waitForTransformDuration());
+			groundTruth = rtabmap_conversions::getTransform(groundTruthFrameId_, groundTruthBaseFrameId_, header.stamp, this->tfBuffer(), this->waitForTransformDuration());
 
 			if(!data.imageRaw().empty() || !data.laserScanRaw().isEmpty())
 			{
@@ -695,7 +696,7 @@ void OdometryROS::processData()
 		else
 		{
 			// Check TF to see if sensor fusion is used (e.g., the output of robot_localization)
-			Transform tfPose = rtabmap_conversions::getTransform(odomFrameId_, frameId_, header.stamp, this->tfListener(), this->waitForTransformDuration());
+			Transform tfPose = rtabmap_conversions::getTransform(odomFrameId_, frameId_, header.stamp, this->tfBuffer(), this->waitForTransformDuration());
 			if(tfPose.isNull())
 			{
 				NODELET_WARN( "Odometry automatically reset to latest computed pose!");
@@ -719,7 +720,7 @@ void OdometryROS::processData()
 	Transform guessCurrentPose;
 	if(!guessFrameId_.empty())
 	{
-		guessCurrentPose = rtabmap_conversions::getTransform(guessFrameId_, frameId_, header.stamp, this->tfListener(), this->waitForTransformDuration());
+		guessCurrentPose = rtabmap_conversions::getTransform(guessFrameId_, frameId_, header.stamp, this->tfBuffer(), this->waitForTransformDuration());
 
 		Transform previousPose = guessPreviousPose_;
 		if(guessPreviousPose_.isNull())
@@ -1068,7 +1069,7 @@ void OdometryROS::processData()
 			else
 			{
 				// Check TF to see if sensor fusion is used (e.g., the output of robot_localization)
-				Transform tfPose = rtabmap_conversions::getTransform(odomFrameId_, frameId_, header.stamp, this->tfListener(), this->waitForTransformDuration());
+				Transform tfPose = rtabmap_conversions::getTransform(odomFrameId_, frameId_, header.stamp, this->tfBuffer(), this->waitForTransformDuration());
 				if(tfPose.isNull())
 				{
 					NODELET_WARN( "Odometry automatically reset to latest computed pose!");

--- a/rtabmap_odom/src/nodelets/icp_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/icp_odometry.cpp
@@ -357,7 +357,7 @@ private:
 		Transform localScanTransform = rtabmap_conversions::getTransform(this->frameId(),
 				scanMsg->header.frame_id,
 				scanMsg->header.stamp,
-				this->tfListener(),
+				this->tfBuffer(),
 				this->waitForTransformDuration());
 		if(localScanTransform.isNull())
 		{
@@ -377,7 +377,7 @@ private:
 					guessFrameId().empty()?frameId():guessFrameId(),
 					scanMsg->header.stamp,
 					scanMsg->header.stamp + ros::Duration().fromSec(scanMsg->ranges.size()*scanMsg->time_increment),
-					this->tfListener(),
+					this->tfBuffer(),
 					this->waitForTransformDuration());
 			if(tmpT.isNull())
 			{
@@ -388,7 +388,7 @@ private:
 					guessFrameId().empty()?frameId():guessFrameId(),
 					*scanMsg, 
 					scanOut,
-					this->tfListener(),
+					this->tfBuffer(),
 					-1.0,
 					laser_geometry::channel_option::Intensity | laser_geometry::channel_option::Timestamp);
 
@@ -405,7 +405,7 @@ private:
 			}
 
 			sensor_msgs::PointCloud2 scanOutDeskewed;
-			if(!pcl_ros::transformPointCloud(scanMsg->header.frame_id, scanOut, scanOutDeskewed, this->tfListener()))
+			if(!pcl_ros::transformPointCloud(scanMsg->header.frame_id, scanOut, scanOutDeskewed, this->tfBuffer()))
 			{
 				ROS_ERROR("Cannot transform back projected scan from \"%s\" frame to \"%s\" frame at time %fs.",
 						(guessFrameId().empty()?frameId():guessFrameId()).c_str(), scanMsg->header.frame_id.c_str(), scanMsg->header.stamp.toSec());
@@ -622,7 +622,7 @@ private:
 			*cloudMsg = *pointCloudMsg;
 		}
 
-		Transform localScanTransform = rtabmap_conversions::getTransform(this->frameId(), cloudMsg->header.frame_id, cloudMsg->header.stamp, this->tfListener(), this->waitForTransformDuration());
+		Transform localScanTransform = rtabmap_conversions::getTransform(this->frameId(), cloudMsg->header.frame_id, cloudMsg->header.stamp, this->tfBuffer(), this->waitForTransformDuration());
 		if(localScanTransform.isNull())
 		{
 			ROS_ERROR("TF of received scan cloud at time %fs is not set, aborting rtabmap update.", cloudMsg->header.stamp.toSec());
@@ -634,7 +634,7 @@ private:
 			if(!guessFrameId().empty())
 			{
 				// deskew with TF
-				if(!rtabmap_conversions::deskew(*pointCloudMsg, *cloudMsg, guessFrameId(), tfListener(), waitForTransformDuration(), deskewingSlerp_))
+				if(!rtabmap_conversions::deskew(*pointCloudMsg, *cloudMsg, guessFrameId(), tfBuffer(), waitForTransformDuration(), deskewingSlerp_))
 				{
 					ROS_ERROR("Failed to deskew input cloud, aborting odometry update!");
 					return;
@@ -650,7 +650,7 @@ private:
 				{
 					// transform in base frame
 					cloudInBaseFrame.reset(new sensor_msgs::PointCloud2);
-					if(!pcl_ros::transformPointCloud(frameId(), *pointCloudMsg, *cloudInBaseFrame, this->tfListener()))
+					if(!pcl_ros::transformPointCloud(frameId(), *pointCloudMsg, *cloudInBaseFrame, this->tfBuffer()))
 					{
 						ROS_ERROR("Cannot transform back projected scan from \"%s\" frame to \"%s\" frame at time %fs.",
 								pointCloudMsg->header.frame_id.c_str(), frameId().c_str(), pointCloudMsg->header.stamp.toSec());
@@ -669,7 +669,7 @@ private:
 				if(!alreadyInBaseFrame)
 				{
 					// put back in scan frame
-					if(!pcl_ros::transformPointCloud(pointCloudMsg->header.frame_id.c_str(), *cloudDeskewed, *cloudMsg, this->tfListener()))
+					if(!pcl_ros::transformPointCloud(pointCloudMsg->header.frame_id.c_str(), *cloudDeskewed, *cloudMsg, this->tfBuffer()))
 					{
 						ROS_ERROR("Cannot transform back projected scan from \"%s\" frame to \"%s\" frame at time %fs.",
 								frameId().c_str(), pointCloudMsg->header.frame_id.c_str(), pointCloudMsg->header.stamp.toSec());

--- a/rtabmap_odom/src/nodelets/rgbd_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/rgbd_odometry.cpp
@@ -487,7 +487,7 @@ private:
 				higherStamp = stamp;
 			}
 
-			Transform localTransform = rtabmap_conversions::getTransform(this->frameId(), rgbImages[i]->header.frame_id, stamp, this->tfListener(), this->waitForTransformDuration());
+			Transform localTransform = rtabmap_conversions::getTransform(this->frameId(), rgbImages[i]->header.frame_id, stamp, this->tfBuffer(), this->waitForTransformDuration());
 			if(localTransform.isNull())
 			{
 				return;

--- a/rtabmap_odom/src/nodelets/rgbdicp_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/rgbdicp_odometry.cpp
@@ -294,7 +294,7 @@ private:
 				}
 			}
 
-			Transform localTransform = rtabmap_conversions::getTransform(this->frameId(), image->header.frame_id, stamp, this->tfListener(), this->waitForTransformDuration());
+			Transform localTransform = rtabmap_conversions::getTransform(this->frameId(), image->header.frame_id, stamp, this->tfBuffer(), this->waitForTransformDuration());
 			if(localTransform.isNull())
 			{
 				return;
@@ -330,7 +330,7 @@ private:
 					localScanTransform = rtabmap_conversions::getTransform(this->frameId(),
 							scanMsg->header.frame_id,
 							scanMsg->header.stamp + ros::Duration().fromSec(scanMsg->ranges.size()*scanMsg->time_increment),
-							this->tfListener(),
+							this->tfBuffer(),
 							this->waitForTransformDuration());
 					if(localScanTransform.isNull())
 					{
@@ -341,7 +341,7 @@ private:
 					//transform in frameId_ frame
 					sensor_msgs::PointCloud2 scanOut;
 					laser_geometry::LaserProjection projection;
-					projection.transformLaserScanToPointCloud(scanMsg->header.frame_id, *scanMsg, scanOut, this->tfListener());
+					projection.transformLaserScanToPointCloud(scanMsg->header.frame_id, *scanMsg, scanOut, this->tfBuffer());
 					pcl::PointCloud<pcl::PointXYZ>::Ptr pclScan(new pcl::PointCloud<pcl::PointXYZ>);
 					pcl::fromROSMsg(scanOut, *pclScan);
 					pclScan->is_dense = true;
@@ -396,7 +396,7 @@ private:
 							}
 						}
 					}
-					localScanTransform = rtabmap_conversions::getTransform(this->frameId(), cloudMsg->header.frame_id, cloudMsg->header.stamp, this->tfListener(), this->waitForTransformDuration());
+					localScanTransform = rtabmap_conversions::getTransform(this->frameId(), cloudMsg->header.frame_id, cloudMsg->header.stamp, this->tfBuffer(), this->waitForTransformDuration());
 					if(localScanTransform.isNull())
 					{
 						ROS_ERROR("TF of received scan cloud at time %fs is not set, aborting rtabmap update.", cloudMsg->header.stamp.toSec());

--- a/rtabmap_odom/src/nodelets/stereo_odometry.cpp
+++ b/rtabmap_odom/src/nodelets/stereo_odometry.cpp
@@ -465,7 +465,7 @@ private:
 				higherStamp = stamp;
 			}
 
-			Transform localTransform = rtabmap_conversions::getTransform(this->frameId(), leftImages[i]->header.frame_id, stamp, this->tfListener(), this->waitForTransformDuration());
+			Transform localTransform = rtabmap_conversions::getTransform(this->frameId(), leftImages[i]->header.frame_id, stamp, this->tfBuffer(), this->waitForTransformDuration());
 			if(localTransform.isNull())
 			{
 				return;
@@ -530,7 +530,7 @@ private:
 								rightCameraInfos[i].header.frame_id,
 								leftCameraInfos[i].header.frame_id,
 								leftCameraInfos[i].header.stamp,
-								this->tfListener(),
+								this->tfBuffer(),
 								this->waitForTransformDuration());
 						if(stereoTransform.isNull())
 						{
@@ -564,7 +564,7 @@ private:
 							leftCameraInfos[i].header.frame_id,
 							rightCameraInfos[i].header.frame_id,
 							leftCameraInfos[i].header.stamp,
-							this->tfListener(),
+							this->tfBuffer(),
 							this->waitForTransformDuration());
 
 					if(!stereoTransform.isNull() && stereoTransform.x()>0)

--- a/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
+++ b/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
@@ -34,7 +34,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <std_srvs/Empty.h>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 
 #include <std_msgs/Empty.h>
@@ -324,7 +325,8 @@ private:
 	std::string goalFrameId_;
 
 	tf2_ros::TransformBroadcaster tfBroadcaster_;
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 
 	ros::ServiceServer updateSrv_;
 	ros::ServiceServer resetSrv_;

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -86,6 +86,7 @@ namespace rtabmap_slam {
 
 CoreWrapper::CoreWrapper() :
 		CommonDataSubscriber(false),
+		tfListener_(tfBuffer_),
 		paused_(false),
 		lastPose_(Transform::getIdentity()),
 		lastPoseIntermediate_(false),
@@ -1047,7 +1048,7 @@ bool CoreWrapper::odomUpdate(const nav_msgs::OdometryConstPtr & odomMsg, ros::Ti
 		{
 			Transform odomTF;
 			if(!stamp.isZero()) {
-				odomTF = rtabmap_conversions::getTransform(odomMsg->header.frame_id, frameId_, stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+				odomTF = rtabmap_conversions::getTransform(odomMsg->header.frame_id, frameId_, stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 			}
 			if(odomTF.isNull())
 			{
@@ -1174,7 +1175,7 @@ bool CoreWrapper::odomTFUpdate(const ros::Time & stamp)
 	if(!paused_)
 	{
 		// Odom TF ready?
-		Transform odom = rtabmap_conversions::getTransform(odomFrameId_, frameId_, stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+		Transform odom = rtabmap_conversions::getTransform(odomFrameId_, frameId_, stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 		if(odom.isNull())
 		{
 			return false;
@@ -1354,7 +1355,7 @@ void CoreWrapper::commonMultiCameraCallbackImpl(
 			depth,
 			cameraModels,
 			stereoCameraModels,
-			tfListener_,
+			tfBuffer_,
 			waitForTransform_?waitForTransformDuration_:0.0,
 			alreadyRectifiedImages_,
 			localKeyPointsMsgs,
@@ -1471,7 +1472,7 @@ void CoreWrapper::commonMultiCameraCallbackImpl(
 				odomSensorSync_?odomFrameId:"",
 				lastPoseStamp_,
 				scan,
-				tfListener_,
+				tfBuffer_,
 				waitForTransform_?waitForTransformDuration_:0,
 				// backward compatibility, project 2D scan in /base_link frame
 				rtabmap_.getMemory() && uStrNumCmp(rtabmap_.getMemory()->getDatabaseVersion(), "0.11.10") < 0))
@@ -1488,7 +1489,7 @@ void CoreWrapper::commonMultiCameraCallbackImpl(
 				odomSensorSync_?odomFrameId:"",
 				lastPoseStamp_,
 				scan,
-				tfListener_,
+				tfBuffer_,
 				waitForTransform_?waitForTransformDuration_:0,
 				scanCloudMaxPoints_,
 				0,
@@ -1676,7 +1677,7 @@ void CoreWrapper::commonLaserScanCallback(
 				odomSensorSync_?odomFrameId:"",
 				lastPoseStamp_,
 				scan,
-				tfListener_,
+				tfBuffer_,
 				waitForTransform_?waitForTransformDuration_:0,
 				// backward compatibility, project 2D scan in /base_link frame
 				rtabmap_.getMemory() && uStrNumCmp(rtabmap_.getMemory()->getDatabaseVersion(), "0.11.10") < 0))
@@ -1693,7 +1694,7 @@ void CoreWrapper::commonLaserScanCallback(
 				odomSensorSync_?odomFrameId:"",
 				lastPoseStamp_,
 				scan,
-				tfListener_,
+				tfBuffer_,
 				waitForTransform_?waitForTransformDuration_:0,
 				scanCloudMaxPoints_,
 				0,
@@ -1917,7 +1918,7 @@ void CoreWrapper::process(
 					Transform gt;
 					if(!groundTruthFrameId_.empty())
 					{
-						gt = rtabmap_conversions::getTransform(groundTruthFrameId_, groundTruthBaseFrameId_, iter->first.header.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+						gt = rtabmap_conversions::getTransform(groundTruthFrameId_, groundTruthBaseFrameId_, iter->first.header.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 					}
 					interData.setGroundTruth(gt);
 
@@ -1971,7 +1972,7 @@ void CoreWrapper::process(
 		Transform groundTruthPose;
 		if(!groundTruthFrameId_.empty())
 		{
-			groundTruthPose = rtabmap_conversions::getTransform(groundTruthFrameId_, groundTruthBaseFrameId_, lastPoseStamp_, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+			groundTruthPose = rtabmap_conversions::getTransform(groundTruthFrameId_, groundTruthBaseFrameId_, lastPoseStamp_, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 		}
 		data.setGroundTruth(groundTruthPose);
 
@@ -1983,7 +1984,7 @@ void CoreWrapper::process(
 					globalPose_.header.frame_id,
 					frameId_,
 					lastPoseStamp_,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0.0);
 			if(!sensorToBase.isNull())
 			{
@@ -1996,7 +1997,7 @@ void CoreWrapper::process(
 						odomFrameId,
 						lastPoseStamp_,
 						globalPose_.header.stamp,
-						tfListener_,
+						tfBuffer_,
 						waitForTransform_?waitForTransformDuration_:0.0);
 				if(!correction.isNull())
 				{
@@ -2026,7 +2027,7 @@ void CoreWrapper::process(
 				frameId_,
 				odomFrameId,
 				lastPoseStamp_,
-				tfListener_,
+				tfBuffer_,
 				waitForTransform_?waitForTransformDuration_:0,
 				landmarkDefaultLinVariance_,
 				landmarkDefaultAngVariance_);
@@ -2053,7 +2054,7 @@ void CoreWrapper::process(
 				rtabmap::Transform localTransform;
 				if(frameId_.compare(imuFrameId_) != 0)
 				{
-					localTransform = rtabmap_conversions::getTransform(frameId_, imuFrameId_, ros::Time(data.stamp()), tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+					localTransform = rtabmap_conversions::getTransform(frameId_, imuFrameId_, ros::Time(data.stamp()), tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 				}
 				else
 				{
@@ -2297,7 +2298,7 @@ void CoreWrapper::process(
 									Transform goalLocalTransform = Transform::getIdentity();
 									if(!goalFrameId_.empty() && goalFrameId_.compare(frameId_) != 0)
 									{
-										Transform localT = rtabmap_conversions::getTransform(frameId_, goalFrameId_, ros::Time::now(), tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+										Transform localT = rtabmap_conversions::getTransform(frameId_, goalFrameId_, ros::Time::now(), tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 										if(!localT.isNull())
 										{
 											goalLocalTransform = localT.inverse().to3DoF();
@@ -2602,7 +2603,7 @@ void CoreWrapper::initialPoseCallback(const geometry_msgs::PoseWithCovarianceSta
 	}
 	else if(msg->header.frame_id != mapFrameId_)
 	{
-		mapToPose = rtabmap_conversions::getTransform(mapFrameId_, msg->header.frame_id, msg->header.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+		mapToPose = rtabmap_conversions::getTransform(mapFrameId_, msg->header.frame_id, msg->header.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 		if(mapToPose.isNull())
 		{
 			NODELET_ERROR("Failed to transform initialpose from frame %s to map frame %s", msg->header.frame_id.c_str(), mapFrameId_.c_str());
@@ -2710,7 +2711,7 @@ void CoreWrapper::goalCommonCallback(
 						Transform goalLocalTransform = Transform::getIdentity();
 						if(!goalFrameId_.empty() && goalFrameId_.compare(frameId_) != 0)
 						{
-							Transform localT = rtabmap_conversions::getTransform(frameId_, goalFrameId_, stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+							Transform localT = rtabmap_conversions::getTransform(frameId_, goalFrameId_, stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 							if(!localT.isNull())
 							{
 								goalLocalTransform = localT.inverse().to3DoF();
@@ -2786,7 +2787,7 @@ void CoreWrapper::goalCallback(const geometry_msgs::PoseStampedConstPtr & msg)
 	// transform goal in /map frame
 	if(!msg->header.frame_id.empty() && mapFrameId_.compare(msg->header.frame_id) != 0)
 	{
-		Transform t = rtabmap_conversions::getTransform(mapFrameId_, msg->header.frame_id, msg->header.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+		Transform t = rtabmap_conversions::getTransform(mapFrameId_, msg->header.frame_id, msg->header.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 		if(t.isNull())
 		{
 			NODELET_ERROR("Cannot transform goal pose from \"%s\" frame to \"%s\" frame!",
@@ -3888,7 +3889,7 @@ bool CoreWrapper::getPlanCallback(nav_msgs::GetPlan::Request &req, nav_msgs::Get
 		Transform coordinateTransform = Transform::getIdentity();
 		if(!req.goal.header.frame_id.empty() && mapFrameId_.compare(req.goal.header.frame_id) != 0)
 		{
-			coordinateTransform = rtabmap_conversions::getTransform(mapFrameId_, req.goal.header.frame_id, req.goal.header.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+			coordinateTransform = rtabmap_conversions::getTransform(mapFrameId_, req.goal.header.frame_id, req.goal.header.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 			if(coordinateTransform.isNull())
 			{
 				NODELET_ERROR("Cannot transform goal pose from \"%s\" frame to \"%s\" frame!",
@@ -3966,7 +3967,7 @@ bool CoreWrapper::getPlanNodesCallback(rtabmap_msgs::GetPlan::Request &req, rtab
 		// transform goal in /map frame
 		if(!pose.isNull() && !req.goal.header.frame_id.empty() && mapFrameId_.compare(req.goal.header.frame_id) != 0)
 		{
-			coordinateTransform = rtabmap_conversions::getTransform(mapFrameId_, req.goal.header.frame_id, req.goal.header.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+			coordinateTransform = rtabmap_conversions::getTransform(mapFrameId_, req.goal.header.frame_id, req.goal.header.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 			if(coordinateTransform.isNull())
 			{
 				NODELET_ERROR("Cannot transform goal pose from \"%s\" frame to \"%s\" frame!",
@@ -4633,7 +4634,7 @@ void CoreWrapper::publishGlobalPath(const ros::Time & stamp)
 			Transform goalLocalTransform = Transform::getIdentity();
 			if(!goalFrameId_.empty() && goalFrameId_.compare(frameId_) != 0)
 			{
-				Transform localT = rtabmap_conversions::getTransform(frameId_, goalFrameId_, stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0.0);
+				Transform localT = rtabmap_conversions::getTransform(frameId_, goalFrameId_, stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 				if(!localT.isNull())
 				{
 					goalLocalTransform = localT.inverse().to3DoF();

--- a/rtabmap_util/CMakeLists.txt
+++ b/rtabmap_util/CMakeLists.txt
@@ -3,7 +3,7 @@ project(rtabmap_util)
 
 find_package(catkin REQUIRED COMPONENTS
              cv_bridge image_transport roscpp nav_msgs sensor_msgs stereo_msgs std_msgs
-             tf laser_geometry pcl_conversions pcl_ros nodelet message_filters
+             tf tf2_ros laser_geometry pcl_conversions pcl_ros nodelet message_filters
              pluginlib rtabmap_msgs rtabmap_conversions
 )
 
@@ -23,7 +23,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES rtabmap_util_plugins
   CATKIN_DEPENDS cv_bridge image_transport roscpp nav_msgs sensor_msgs stereo_msgs std_msgs
-             tf laser_geometry pcl_conversions pcl_ros nodelet message_filters
+             tf tf2_ros laser_geometry pcl_conversions pcl_ros nodelet message_filters
              pluginlib rtabmap_msgs rtabmap_conversions ${optional_dependencies}
 )
 

--- a/rtabmap_util/package.xml
+++ b/rtabmap_util/package.xml
@@ -20,6 +20,7 @@
   <depend>stereo_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf</depend>
+  <depend>tf2_ros</depend>
   <depend>laser_geometry</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>

--- a/rtabmap_util/src/nodelets/imu_to_tf.cpp
+++ b/rtabmap_util/src/nodelets/imu_to_tf.cpp
@@ -82,7 +82,11 @@ private:
 			try
 			{
 				geometry_msgs::TransformStamped tmpMsg;
-				tmpMsg = tfBuffer_.lookupTransform(baseFrameId_, msg->header.frame_id, msg->header.stamp, ros::Duration(waitForTransformDuration_));
+				tmpMsg = tfBuffer_.lookupTransform(
+						!baseFrameId_.empty()&&baseFrameId_.at(0)=='/'?baseFrameId_.substr(1):baseFrameId_,
+						!msg->header.frame_id.empty()&&msg->header.frame_id.at(0)=='/'?msg->header.frame_id.substr(1):msg->header.frame_id,
+						msg->header.stamp,
+						ros::Duration(waitForTransformDuration_));
 				tf::Transform tmp;
 				tf::transformMsgToTF(tmpMsg.transform, tmp);
 				tf::Quaternion q;

--- a/rtabmap_util/src/nodelets/imu_to_tf.cpp
+++ b/rtabmap_util/src/nodelets/imu_to_tf.cpp
@@ -30,8 +30,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <nodelet/nodelet.h>
 #include <sensor_msgs/Imu.h>
 #include <tf/transform_broadcaster.h>
+#include <tf/transform_datatypes.h>
 #include <tf/LinearMath/Matrix3x3.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 namespace rtabmap_util
 {
@@ -41,6 +43,7 @@ class ImuToTF : public nodelet::Nodelet
 public:
 	ImuToTF() :
 		fixedFrameId_("odom"),
+		tfListener_(tfBuffer_),
 		waitForTransformDuration_(0.1)
 	{}
 
@@ -78,23 +81,17 @@ private:
 		{
 			try
 			{
-				std::string errorMsg;
-				if(!tfListener_.waitForTransform(baseFrameId_, msg->header.frame_id, msg->header.stamp, ros::Duration(waitForTransformDuration_), ros::Duration(0.01), &errorMsg))
-				{
-					NODELET_ERROR("Could not get transform from %s to %s after %f seconds (for stamp=%f)! Error=\"%s\".",
-							baseFrameId_.c_str(), msg->header.frame_id.c_str(), 0.1, msg->header.stamp.toSec(), errorMsg.c_str());
-					return;
-				}
-
-				tf::StampedTransform tmp;
-				tfListener_.lookupTransform(baseFrameId_, msg->header.frame_id, msg->header.stamp, tmp);
+				geometry_msgs::TransformStamped tmpMsg;
+				tmpMsg = tfBuffer_.lookupTransform(baseFrameId_, msg->header.frame_id, msg->header.stamp, ros::Duration(waitForTransformDuration_));
+				tf::Transform tmp;
+				tf::transformMsgToTF(tmpMsg.transform, tmp);
 				tf::Quaternion q;
 				q.setRPY(0.0,0.0,tf::getYaw(tmp.getRotation()));
 				tf::Transform t = tf::Transform(q)*st*tmp.inverse(); // base_frame orientation
 				st.setRotation(t.getRotation());
 				st.child_frame_id_ = baseFrameId_;
 			}
-			catch(tf::TransformException & ex)
+			catch(tf2::TransformException & ex)
 			{
 				NODELET_ERROR("(getting transform %s -> %s) %s", baseFrameId_.c_str(), msg->header.frame_id.c_str(), ex.what());
 				return;
@@ -114,7 +111,8 @@ private:
 	tf::TransformBroadcaster pub_;
 	std::string fixedFrameId_;
 	std::string baseFrameId_;
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 	double waitForTransformDuration_;
 };
 

--- a/rtabmap_util/src/nodelets/lidar_deskewing.cpp
+++ b/rtabmap_util/src/nodelets/lidar_deskewing.cpp
@@ -3,7 +3,8 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/LaserScan.h>
@@ -31,12 +32,13 @@ public:
 
 	virtual ~LidarDeskewing()
 	{
+		delete tfListener_;
 	}
 
 private:
 	virtual void onInit()
 	{
-		tfListener_ = new tf::TransformListener();
+		tfListener_ = new tf2_ros::TransformListener(tfBuffer_);
 		ros::NodeHandle & nh = getNodeHandle();
 		ros::NodeHandle & pnh = getPrivateNodeHandle();
 
@@ -67,7 +69,7 @@ private:
 				fixedFrameId_,
 				msg->header.stamp,
 				msg->header.stamp + ros::Duration().fromSec(msg->ranges.size()*msg->time_increment),
-				*tfListener_,
+				tfBuffer_,
 				waitForTransformDuration_);
 		if(tmpT.isNull())
 		{
@@ -76,10 +78,10 @@ private:
 
 		sensor_msgs::PointCloud2 scanOut;
 		laser_geometry::LaserProjection projection;
-		projection.transformLaserScanToPointCloud(fixedFrameId_, *msg, scanOut, *tfListener_);
+		projection.transformLaserScanToPointCloud(fixedFrameId_, *msg, scanOut, tfBuffer_);
 
 		sensor_msgs::PointCloud2 scanOutDeskewed;
-		if(!pcl_ros::transformPointCloud(msg->header.frame_id, scanOut, scanOutDeskewed, *tfListener_))
+		if(!pcl_ros::transformPointCloud(msg->header.frame_id, scanOut, scanOutDeskewed, tfBuffer_))
 		{
 			ROS_ERROR("Cannot transform back projected scan from \"%s\" frame to \"%s\" frame at time %fs.",
 					fixedFrameId_.c_str(), msg->header.frame_id.c_str(), msg->header.stamp.toSec());
@@ -91,7 +93,7 @@ private:
 	void callbackCloud(const sensor_msgs::PointCloud2ConstPtr & msg)
 	{
 		sensor_msgs::PointCloud2 msgDeskewed;
-		if(rtabmap_conversions::deskew(*msg, msgDeskewed, fixedFrameId_, *tfListener_, waitForTransformDuration_, slerp_))
+		if(rtabmap_conversions::deskew(*msg, msgDeskewed, fixedFrameId_, tfBuffer_, waitForTransformDuration_, slerp_))
 		{
 			pubCloud_.publish(msgDeskewed);
 		}
@@ -112,7 +114,8 @@ private:
 	std::string fixedFrameId_;
 	double waitForTransformDuration_;
 	bool slerp_;
-	tf::TransformListener * tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener * tfListener_;
 };
 
 PLUGINLIB_EXPORT_CLASS(rtabmap_util::LidarDeskewing, nodelet::Nodelet);

--- a/rtabmap_util/src/nodelets/obstacles_detection.cpp
+++ b/rtabmap_util/src/nodelets/obstacles_detection.cpp
@@ -251,7 +251,11 @@ private:
 		try
 		{
 			geometry_msgs::TransformStamped tmp;
-			tmp = tfBuffer_.lookupTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, ros::Duration(waitForTransform_?1.0:0.0));
+			tmp = tfBuffer_.lookupTransform(
+					!frameId_.empty()&&frameId_.at(0)=='/'?frameId_.substr(1):frameId_,
+					!cloudMsg->header.frame_id.empty()&&cloudMsg->header.frame_id.at(0)=='/'?cloudMsg->header.frame_id.substr(1):cloudMsg->header.frame_id,
+					cloudMsg->header.stamp,
+					ros::Duration(waitForTransform_?1.0:0.0));
 			localTransform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 		}
 		catch(tf2::TransformException & ex)
@@ -266,7 +270,11 @@ private:
 			try
 			{
 				geometry_msgs::TransformStamped tmp;
-				tmp = tfBuffer_.lookupTransform(mapFrameId_, frameId_, cloudMsg->header.stamp, ros::Duration(waitForTransform_?1.0:0.0));
+				tmp = tfBuffer_.lookupTransform(
+						!mapFrameId_.empty()&&mapFrameId_.at(0)=='/'?mapFrameId_.substr(1):mapFrameId_,
+						!frameId_.empty()&&frameId_.at(0)=='/'?frameId_.substr(1):frameId_,
+						cloudMsg->header.stamp,
+						ros::Duration(waitForTransform_?1.0:0.0));
 				pose = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 			}
 			catch(tf2::TransformException & ex)

--- a/rtabmap_util/src/nodelets/obstacles_detection.cpp
+++ b/rtabmap_util/src/nodelets/obstacles_detection.cpp
@@ -35,7 +35,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <pcl/filters/filter.h>
 #include <rtabmap/core/LocalGridMaker.h>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <sensor_msgs/PointCloud2.h>
 
@@ -53,7 +54,8 @@ public:
 		frameId_("base_link"),
 		waitForTransform_(false),
 		mapFrameProjection_(rtabmap::Parameters::defaultGridMapFrameProjection()),
-		warned_(false)
+		warned_(false),
+		tfListener_(tfBuffer_)
 	{}
 
 	virtual ~ObstaclesDetection()
@@ -248,19 +250,11 @@ private:
 		rtabmap::Transform localTransform = rtabmap::Transform::getIdentity();
 		try
 		{
-			if(waitForTransform_)
-			{
-				if(!tfListener_.waitForTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, ros::Duration(1)))
-				{
-					NODELET_ERROR("Could not get transform from %s to %s after 1 second!", frameId_.c_str(), cloudMsg->header.frame_id.c_str());
-					return;
-				}
-			}
-			tf::StampedTransform tmp;
-			tfListener_.lookupTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, tmp);
-			localTransform = rtabmap_conversions::transformFromTF(tmp);
+			geometry_msgs::TransformStamped tmp;
+			tmp = tfBuffer_.lookupTransform(frameId_, cloudMsg->header.frame_id, cloudMsg->header.stamp, ros::Duration(waitForTransform_?1.0:0.0));
+			localTransform = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 		}
-		catch(tf::TransformException & ex)
+		catch(tf2::TransformException & ex)
 		{
 			NODELET_ERROR("%s",ex.what());
 			return;
@@ -271,19 +265,11 @@ private:
 		{
 			try
 			{
-				if(waitForTransform_)
-				{
-					if(!tfListener_.waitForTransform(mapFrameId_, frameId_, cloudMsg->header.stamp, ros::Duration(1)))
-					{
-						NODELET_ERROR("Could not get transform from %s to %s after 1 second!", mapFrameId_.c_str(), frameId_.c_str());
-						return;
-					}
-				}
-				tf::StampedTransform tmp;
-				tfListener_.lookupTransform(mapFrameId_, frameId_, cloudMsg->header.stamp, tmp);
-				pose = rtabmap_conversions::transformFromTF(tmp);
+				geometry_msgs::TransformStamped tmp;
+				tmp = tfBuffer_.lookupTransform(mapFrameId_, frameId_, cloudMsg->header.stamp, ros::Duration(waitForTransform_?1.0:0.0));
+				pose = rtabmap_conversions::transformFromGeometryMsg(tmp.transform);
 			}
-			catch(tf::TransformException & ex)
+			catch(tf2::TransformException & ex)
 			{
 				NODELET_ERROR("%s",ex.what());
 				return;
@@ -443,7 +429,8 @@ private:
 	bool mapFrameProjection_;
 	bool warned_;
 
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 
 	ros::Publisher groundPub_;
 	ros::Publisher obstaclesPub_;

--- a/rtabmap_util/src/nodelets/point_cloud_aggregator.cpp
+++ b/rtabmap_util/src/nodelets/point_cloud_aggregator.cpp
@@ -36,7 +36,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <pcl_ros/transforms.h>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <sensor_msgs/PointCloud2.h>
 
@@ -73,7 +74,8 @@ public:
 		exactSync2_(0),
 		approxSync2_(0),
 		waitForTransformDuration_(0.1),
-		xyzOutput_(false)
+		xyzOutput_(false),
+		tfListener_(tfBuffer_)
 	{}
 
 	virtual ~PointCloudAggregator()
@@ -250,7 +252,7 @@ private:
 			if(!frameId.empty() && frameId.compare(cloudMsgs[0]->header.frame_id) != 0)
 			{
 				sensor_msgs::PointCloud2 tmp;
-				pcl_ros::transformPointCloud(frameId, *cloudMsgs[0], tmp, tfListener_);
+				pcl_ros::transformPointCloud(frameId, *cloudMsgs[0], tmp, tfBuffer_);
 				pcl_conversions::toPCL(tmp, *output);
 			}
 			else
@@ -307,7 +309,7 @@ private:
 							fixedFrameId_, //fixedFrame
 							cloudMsgs[0]->header.stamp, //stampTarget
 							cloudMsgs[i]->header.stamp, //stampSource
-							tfListener_,
+							tfBuffer_,
 							waitForTransformDuration_);
 				}
 
@@ -315,7 +317,7 @@ private:
 				if(frameId.compare(cloudMsgs[i]->header.frame_id) != 0)
 				{
 					sensor_msgs::PointCloud2 tmp;
-					pcl_ros::transformPointCloud(frameId, *cloudMsgs[i], tmp, tfListener_);
+					pcl_ros::transformPointCloud(frameId, *cloudMsgs[i], tmp, tfBuffer_);
 					if(!cloudDisplacement.isNull())
 					{
 						sensor_msgs::PointCloud2 tmp2;
@@ -468,7 +470,8 @@ private:
 	std::string fixedFrameId_;
 	double waitForTransformDuration_;
 	bool xyzOutput_;
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 };
 
 PLUGINLIB_EXPORT_CLASS(rtabmap_util::PointCloudAggregator, nodelet::Nodelet);

--- a/rtabmap_util/src/nodelets/point_cloud_assembler.cpp
+++ b/rtabmap_util/src/nodelets/point_cloud_assembler.cpp
@@ -38,7 +38,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <pcl_ros/transforms.h>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <nav_msgs/Odometry.h>
 #include <sensor_msgs/PointCloud2.h>
@@ -87,7 +88,8 @@ public:
 		noiseMinNeighbors_(5),
 		removeZ_(false),
 		fixedFrameId_("odom"),
-		frameId_("")
+		frameId_(""),
+		tfListener_(tfBuffer_)
 	{}
 
 	virtual ~PointCloudAssembler()
@@ -316,7 +318,7 @@ private:
 						fixedFrameId_, //fromFrame
 						cloudMsg->header.frame_id, //toFrame
 						cloudMsg->header.stamp,
-						tfListener_,
+						tfBuffer_,
 						waitForTransformDuration_);
 
 				if(pose.isNull())
@@ -475,7 +477,7 @@ private:
 								fixedFrameId_, //fromFrame
 								frameId_, //toFrame
 								cloudMsg->header.stamp,
-								tfListener_,
+								tfBuffer_,
 								waitForTransformDuration_);
 						if(t.isNull())
 						{
@@ -582,7 +584,8 @@ private:
 	bool removeZ_;
 	std::string fixedFrameId_;
 	std::string frameId_;
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 	rtabmap::Transform previousPose_;
 
 	std::list<pcl::PCLPointCloud2::Ptr> clouds_;

--- a/rtabmap_util/src/nodelets/pointcloud_to_depthimage.cpp
+++ b/rtabmap_util/src/nodelets/pointcloud_to_depthimage.cpp
@@ -52,6 +52,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/subscriber.h>
 
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
 namespace rtabmap_util
 {
 
@@ -87,7 +90,7 @@ public:
 private:
 	virtual void onInit()
 	{
-		listener_ = new tf::TransformListener();
+		listener_ = new tf2_ros::TransformListener(tfBuffer_);
 
 		ros::NodeHandle & nh = getNodeHandle();
 		ros::NodeHandle & pnh = getPrivateNodeHandle();
@@ -179,7 +182,7 @@ private:
 						fixedFrameId_,
 						pointCloud2Msg->header.stamp,
 						cameraInfoMsg->header.stamp,
-						*listener_,
+						tfBuffer_,
 						waitForTransform_);
 			}
 
@@ -192,7 +195,7 @@ private:
 					pointCloud2Msg->header.frame_id,
 					cameraInfoMsg->header.frame_id,
 					cameraInfoMsg->header.stamp,
-					*listener_,
+					tfBuffer_,
 					waitForTransform_);
 
 			if(cloudToCamera.isNull())
@@ -306,7 +309,8 @@ private:
 	message_filters::Subscriber<sensor_msgs::PointCloud2> pointCloudSub_;
 	message_filters::Subscriber<sensor_msgs::CameraInfo> cameraInfoSub_;
 	std::string fixedFrameId_;
-	tf::TransformListener * listener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener * listener_;
 	double waitForTransform_;
 	int fillHolesSize_;
 	double fillHolesError_;

--- a/rtabmap_viz/CMakeLists.txt
+++ b/rtabmap_viz/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(rtabmap_viz)
 
 find_package(catkin REQUIRED COMPONENTS
-             cv_bridge geometry_msgs std_msgs std_srvs nav_msgs rtabmap_msgs rtabmap_sync tf
+             cv_bridge geometry_msgs std_msgs std_srvs nav_msgs rtabmap_msgs rtabmap_sync tf tf2_ros
 )
 
 ###################################
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS cv_bridge geometry_msgs std_msgs std_srvs nav_msgs rtabmap_msgs rtabmap_sync tf
+  CATKIN_DEPENDS cv_bridge geometry_msgs std_msgs std_srvs nav_msgs rtabmap_msgs rtabmap_sync tf tf2_ros
 )
 
 # catkin is not using cmake targets for dependencies,

--- a/rtabmap_viz/include/rtabmap_viz/GuiWrapper.h
+++ b/rtabmap_viz/include/rtabmap_viz/GuiWrapper.h
@@ -36,7 +36,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UEventsHandler.h"
 #include "rtabmap/core/Transform.h"
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <geometry_msgs/TwistStamped.h>
 #include <nav_msgs/Path.h>
@@ -133,7 +134,8 @@ private:
 	double waitForTransformDuration_;
 	bool odomSensorSync_;
 	double maxOdomUpdateRate_;
-	tf::TransformListener tfListener_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
 
 	ros::Publisher republishNodeDataPub_;
 

--- a/rtabmap_viz/package.xml
+++ b/rtabmap_viz/package.xml
@@ -19,5 +19,6 @@
   <depend>rtabmap_msgs</depend>
   <depend>rtabmap_sync</depend>
   <depend>tf</depend>
+  <depend>tf2_ros</depend>
 
 </package>

--- a/rtabmap_viz/src/GuiWrapper.cpp
+++ b/rtabmap_viz/src/GuiWrapper.cpp
@@ -73,6 +73,7 @@ GuiWrapper::GuiWrapper(int & argc, char** argv) :
 		waitForTransformDuration_(0.2), // 200 ms
 		odomSensorSync_(false),
 		maxOdomUpdateRate_(10),
+		tfListener_(tfBuffer_),
 		cameraNodeName_(""),
 		lastOdomInfoUpdateTime_(0),
 		rtabmapNodeName_("rtabmap")
@@ -541,7 +542,7 @@ void GuiWrapper::commonMultiCameraCallback(
 		odomHeader.frame_id = odomFrameId_;
 	}
 
-	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0);
+	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0);
 	cv::Mat covariance = cv::Mat::eye(6,6,CV_64FC1);
 	if(odomMsg.get())
 	{
@@ -608,7 +609,7 @@ void GuiWrapper::commonMultiCameraCallback(
 					depth,
 					cameraModels,
 					stereoCameraModels,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0.0,
 					imagesAlreadyRectified))
 			{
@@ -625,7 +626,7 @@ void GuiWrapper::commonMultiCameraCallback(
 					odomSensorSync_?odomHeader.frame_id:"",
 					odomHeader.stamp,
 					scan,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0))
 			{
 				ROS_ERROR("Could not convert laser scan msg! Aborting rtabmap_viz update...");
@@ -640,7 +641,7 @@ void GuiWrapper::commonMultiCameraCallback(
 					odomSensorSync_?odomHeader.frame_id:"",
 					odomHeader.stamp,
 					scan,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0))
 			{
 				ROS_ERROR("Could not convert 3d laser scan msg! Aborting rtabmap_viz update...");
@@ -734,7 +735,7 @@ void GuiWrapper::commonStereoCallback(
 		odomHeader.frame_id = odomFrameId_;
 	}
 
-	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0);
+	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0);
 	cv::Mat covariance = cv::Mat::eye(6,6,CV_64FC1);
 	if(odomMsg.get())
 	{
@@ -797,7 +798,7 @@ void GuiWrapper::commonStereoCallback(
 				left,
 				right,
 				stereoModel,
-				tfListener_,
+				tfBuffer_,
 				waitForTransform_?waitForTransformDuration_:0.0,
 				imagesAlreadyRectified))
 		{
@@ -813,7 +814,7 @@ void GuiWrapper::commonStereoCallback(
 					odomSensorSync_?odomHeader.frame_id:"",
 					odomHeader.stamp,
 					scan,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0))
 			{
 				ROS_ERROR("Could not convert laser scan msg! Aborting rtabmap_viz update...");
@@ -828,7 +829,7 @@ void GuiWrapper::commonStereoCallback(
 					odomSensorSync_?odomHeader.frame_id:"",
 					odomHeader.stamp,
 					scan,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0))
 			{
 				ROS_ERROR("Could not convert 3d laser scan msg! Aborting rtabmap_viz update...");
@@ -907,7 +908,7 @@ void GuiWrapper::commonLaserScanCallback(
 		odomHeader.frame_id = odomFrameId_;
 	}
 
-	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0);
+	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0);
 	cv::Mat covariance = cv::Mat::eye(6,6,CV_64FC1);
 	if(odomMsg.get())
 	{
@@ -960,7 +961,7 @@ void GuiWrapper::commonLaserScanCallback(
 					odomSensorSync_?odomHeader.frame_id:"",
 					odomHeader.stamp,
 					scan,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0))
 			{
 				ROS_ERROR("Could not convert laser scan msg! Aborting rtabmap_viz update...");
@@ -975,7 +976,7 @@ void GuiWrapper::commonLaserScanCallback(
 					odomSensorSync_?odomHeader.frame_id:"",
 					odomHeader.stamp,
 					scan,
-					tfListener_,
+					tfBuffer_,
 					waitForTransform_?waitForTransformDuration_:0))
 			{
 				ROS_ERROR("Could not convert 3d laser scan msg! Aborting rtabmap_viz update...");
@@ -1024,7 +1025,7 @@ void GuiWrapper::commonOdomCallback(
 
 	std_msgs::Header odomHeader = odomMsg->header;
 
-	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, odomMsg->child_frame_id, odomHeader.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0);
+	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, odomMsg->child_frame_id, odomHeader.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0);
 	cv::Mat covariance = cv::Mat::eye(6,6,CV_64FC1);
 	if(odomMsg.get())
 	{
@@ -1113,7 +1114,7 @@ void GuiWrapper::commonSensorDataCallback(
 		odomHeader.frame_id = odomFrameId_;
 	}
 
-	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfListener_, waitForTransform_?waitForTransformDuration_:0);
+	Transform odomT = rtabmap_conversions::getTransform(odomHeader.frame_id, frameId, odomHeader.stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0);
 	cv::Mat covariance = cv::Mat::eye(6,6,CV_64FC1);
 	if(odomMsg.get())
 	{


### PR DESCRIPTION
When the computer/robot has flaky clock/ntp (time jumping), it may cause crashes in tf::TransformListener with error like:
```
terminate called after throwing an instance of 'boost::wrapexcept<boost::bad_weak_ptr>'
what():  tr1::bad_weak_ptr
```
Changes are based on the similar migration we did for ROS2 branch.