### PR TITLE
Multithreaded rtabmap node (ROS1 port of #1214)

### DIFF
--- a/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
+++ b/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h
@@ -30,7 +30,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <ros/ros.h>
+#include <ros/callback_queue.h>
 #include <nodelet/nodelet.h>
+
+#include <boost/thread.hpp>
 
 #include <std_srvs/Empty.h>
 
@@ -186,6 +189,10 @@ private:
 	void goalCallback(const geometry_msgs::PoseStampedConstPtr & msg);
 	void goalNodeCallback(const rtabmap_msgs::GoalConstPtr & msg);
 	void updateGoal(const ros::Time & stamp);
+
+	// Called on the nodelet's single-threaded callback queue, so it is
+	// mutually exclusive with all services and the other subscriptions.
+	void processAsync(const ros::WallTimerEvent & event);
 
 	void process(
 			const ros::Time & stamp,
@@ -409,6 +416,37 @@ private:
 	ros::Time previousStamp_;
 
 	rtabmap_util::ULogToRosout ulogToRosout_;
+
+	// Asynchronous processing: the synchronized input topics are subscribed on
+	// their own single-threaded callback queue (dataQueue_/dataSpinner_), while
+	// process() runs from syncTimer_ on the nodelet's single-threaded callback
+	// queue, together with all services. A frame received while a previous one
+	// is still pending or being processed is dropped instead of being queued,
+	// which keeps the delay bounded by the processing time instead of letting
+	// it grow with the transport queues.
+	struct SyncData {
+		SyncData() : valid(false), timeMsgConversion(0.0) {}
+		bool valid;
+		ros::Time stamp;
+		rtabmap::SensorData data;
+		rtabmap::Transform odom;
+		std::vector<float> odomVelocity;
+		std::string odomFrameId;
+		cv::Mat odomCovariance;
+		rtabmap::OdometryInfo odomInfo;
+		double timeMsgConversion;
+	};
+	SyncData syncData_;
+	boost::mutex syncDataMutex_;  // held by processAsync() for the whole process()
+	boost::mutex lastPoseMutex_;  // guards lastPose*_, covariance_ and previousStamp_
+	boost::mutex userDataMutex_;  // guards userData_, written by both threads
+	bool triggerNewMapBeforeNextUpdate_;
+
+	ros::CallbackQueue dataQueue_;
+	boost::shared_ptr<ros::AsyncSpinner> dataSpinner_;
+	ros::NodeHandle dataNh_;
+	ros::NodeHandle dataPnh_;
+	ros::WallTimer syncTimer_;
 
 	class LocalizationStatusTask : public diagnostic_updater::DiagnosticTask
 	{

--- a/rtabmap_slam/src/CoreWrapper.cpp
+++ b/rtabmap_slam/src/CoreWrapper.cpp
@@ -131,7 +131,8 @@ CoreWrapper::CoreWrapper() :
 		alreadyRectifiedImages_(Parameters::defaultRtabmapImagesAlreadyRectified()),
 		twoDMapping_(Parameters::defaultRegForce3DoF()),
 		previousStamp_(0),
-		mbClient_(0)
+		mbClient_(0),
+		triggerNewMapBeforeNextUpdate_(false)
 {
 	char * rosHomePath = getenv("ROS_HOME");
 	std::string workingDir = rosHomePath?rosHomePath:UDirectory::homeDir()+"/.ros";
@@ -143,6 +144,23 @@ void CoreWrapper::onInit()
 {
 	ros::NodeHandle & nh = getNodeHandle();
 	ros::NodeHandle & pnh = getPrivateNodeHandle();
+
+	// The synchronized input topics are subscribed on their own callback queue,
+	// served by a single thread, so that they keep being processed (and dropped)
+	// while process() is running. Everything else (services, async sensor topics,
+	// and the syncTimer_ triggering process()) stays on the nodelet's
+	// single-threaded queue, which keeps them all mutually exclusive.
+	dataNh_ = ros::NodeHandle(nh);
+	dataPnh_ = ros::NodeHandle(pnh);
+	dataNh_.setCallbackQueue(&dataQueue_);
+	dataPnh_.setCallbackQueue(&dataQueue_);
+
+	syncTimer_ = nh.createWallTimer(
+			ros::WallDuration(0.001),
+			&CoreWrapper::processAsync,
+			this,
+			true,   // oneshot
+			false); // don't autostart
 
 	mapsManager_.init(nh, pnh, getName(), true);
 
@@ -763,7 +781,7 @@ void CoreWrapper::onInit()
 		localizationDiagnostic_.setLocalizationThreshold(localizationThreshold);
 		tasks.push_back(&localizationDiagnostic_);
 	}
-	setupCallbacks(nh, pnh, getName(), tasks); // do it at the end
+	setupCallbacks(dataNh_, dataPnh_, getName(), tasks); // do it at the end
 	if(!this->isDataSubscribed())
 	{
 		bool isRGBD = uStr2Bool(parameters_.at(Parameters::kRGBDEnabled()).c_str());
@@ -875,10 +893,28 @@ void CoreWrapper::onInit()
 #endif
 	imuSub_ = nh.subscribe("imu", 100, &CoreWrapper::imuAsyncCallback, this);
 	republishNodeDataSub_ = nh.subscribe("republish_node_data", 100, &CoreWrapper::republishNodeDataCallback, this);
+
+	// Start serving the synchronized input topics only once everything above is
+	// constructed, otherwise a callback could fire on a half-initialized node.
+	dataSpinner_.reset(new ros::AsyncSpinner(1, &dataQueue_));
+	dataSpinner_->start();
 }
 
 CoreWrapper::~CoreWrapper()
 {
+	// Stop feeding new data before tearing anything down, then make sure a frame
+	// currently being converted is done with syncData_.
+	if(dataSpinner_.get())
+	{
+		dataSpinner_->stop();
+		dataSpinner_.reset();
+	}
+	syncTimer_.stop();
+	{
+		boost::mutex::scoped_lock lock(syncDataMutex_);
+		syncData_.valid = false;
+	}
+
 	if(transformThread_)
 	{
 		tfThreadRunning_ = false;
@@ -1069,12 +1105,15 @@ bool CoreWrapper::odomUpdate(const nav_msgs::OdometryConstPtr & odomMsg, ros::Ti
 			}
 		}
 
+		boost::mutex::scoped_lock lock(lastPoseMutex_);
+
 		if(!lastPose_.isIdentity() && !odom.isNull() && (odom.isIdentity() || (odomMsg->pose.covariance[0] >= BAD_COVARIANCE && odomMsg->twist.covariance[0] >= BAD_COVARIANCE)))
 		{
 			UWARN("Odometry is reset (identity pose or high variance (%f) detected). Increment map id!", MAX(odomMsg->pose.covariance[0], odomMsg->twist.covariance[0]));
-			rtabmap_.triggerNewMap();
+			// Deferred: rtabmap_ is only touched from the processing thread.
+			triggerNewMapBeforeNextUpdate_ = true;
 			covariance_ = cv::Mat();
-		} 
+		}
 		else if(stalenessFactor_>0.0 && 
 			    previousStamp_.toSec() > 0.0 && 
 				rate_>0.0f && 
@@ -1092,7 +1131,8 @@ bool CoreWrapper::odomUpdate(const nav_msgs::OdometryConstPtr & odomMsg, ros::Ti
 				1.0f/rate_,
 				stalenessFactor_,
 				stalenessFactor_/rate_);
-			rtabmap_.triggerNewMap();
+			// Deferred: rtabmap_ is only touched from the processing thread.
+			triggerNewMapBeforeNextUpdate_ = true;
 			covariance_ = cv::Mat();
 		}
 
@@ -1160,10 +1200,9 @@ bool CoreWrapper::odomUpdate(const nav_msgs::OdometryConstPtr & odomMsg, ros::Ti
 				return false;
 			}
 		}
-		else if(!ignoreFrame)
-		{
-			previousStamp_ = stamp;
-		}
+		// previousStamp_ is advanced by the callback once the frame is actually
+		// accepted for processing, so that a frame dropped because the previous
+		// one is still being processed doesn't shift the detection rate window.
 
 		return true;
 	}
@@ -1174,17 +1213,27 @@ bool CoreWrapper::odomTFUpdate(const ros::Time & stamp)
 {
 	if(!paused_)
 	{
+		// odomFrameId_ is written by process() on the processing thread.
+		std::string odomFrameId;
+		{
+			boost::mutex::scoped_lock lock(mapToOdomMutex_);
+			odomFrameId = odomFrameId_;
+		}
+
 		// Odom TF ready?
-		Transform odom = rtabmap_conversions::getTransform(odomFrameId_, frameId_, stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
+		Transform odom = rtabmap_conversions::getTransform(odomFrameId, frameId_, stamp, tfBuffer_, waitForTransform_?waitForTransformDuration_:0.0);
 		if(odom.isNull())
 		{
 			return false;
 		}
 
+		boost::mutex::scoped_lock lock(lastPoseMutex_);
+
 		if(!lastPose_.isIdentity() && odom.isIdentity())
 		{
 			UWARN("Odometry is reset (identity pose detected). Increment map id!");
-			rtabmap_.triggerNewMap();
+			// Deferred: rtabmap_ is only touched from the processing thread.
+			triggerNewMapBeforeNextUpdate_ = true;
 			covariance_ = cv::Mat();
 		}
 		else if(stalenessFactor_>0.0 && 
@@ -1204,7 +1253,8 @@ bool CoreWrapper::odomTFUpdate(const ros::Time & stamp)
 				1.0f/rate_,
 				stalenessFactor_,
 				stalenessFactor_/rate_);
-			rtabmap_.triggerNewMap();
+			// Deferred: rtabmap_ is only touched from the processing thread.
+			triggerNewMapBeforeNextUpdate_ = true;
 			covariance_ = cv::Mat();
 		}
 
@@ -1237,10 +1287,7 @@ bool CoreWrapper::odomTFUpdate(const ros::Time & stamp)
 				return false;
 			}
 		}
-		else if(!ignoreFrame)
-		{
-			previousStamp_ = stamp;
-		}
+		// See odomUpdate(): previousStamp_ is advanced by the callback instead.
 
 		return true;
 	}
@@ -1262,7 +1309,11 @@ void CoreWrapper::commonMultiCameraCallback(
 		const std::vector<std::vector<rtabmap_msgs::Point3f> > & localPoints3d,
 		const std::vector<cv::Mat> & localDescriptors)
 {
-	std::string odomFrameId = odomFrameId_;
+	std::string odomFrameId;
+	{
+		boost::mutex::scoped_lock lock(mapToOdomMutex_);
+		odomFrameId = odomFrameId_;
+	}
 	if(odomMsg.get())
 	{
 		odomFrameId = odomMsg->header.frame_id;
@@ -1304,6 +1355,16 @@ void CoreWrapper::commonMultiCameraCallback(
 		return;
 	}
 
+	// Drop the frame if a previous one is still pending or being processed:
+	// the lock fails while processAsync() holds it, and syncData_.valid means a
+	// converted frame is already waiting for the processing thread.
+	boost::unique_lock<boost::mutex> lock(syncDataMutex_, boost::try_to_lock);
+	if(!lock.owns_lock() || syncData_.valid)
+	{
+		return;
+	}
+	boost::mutex::scoped_lock poseLock(lastPoseMutex_);
+
 	commonMultiCameraCallbackImpl(odomFrameId,
 			userDataMsg,
 			imageMsgs,
@@ -1317,6 +1378,17 @@ void CoreWrapper::commonMultiCameraCallback(
 			localKeyPoints,
 			localPoints3d,
 			localDescriptors);
+
+	// Re-arm outside the locks: ros::WallTimer::stop() blocks until a running
+	// timer callback has returned, and processAsync() takes syncDataMutex_.
+	bool scheduled = syncData_.valid;
+	poseLock.unlock();
+	lock.unlock();
+	if(scheduled)
+	{
+		syncTimer_.stop();
+		syncTimer_.start();
+	}
 }
 
 void CoreWrapper::commonMultiCameraCallbackImpl(
@@ -1552,6 +1624,7 @@ void CoreWrapper::commonMultiCameraCallbackImpl(
 	if(userDataMsg.get())
 	{
 		userData = rtabmap_conversions::userDataFromROS(*userDataMsg);
+		boost::mutex::scoped_lock userDataLock(userDataMutex_);
 		if(!userData_.empty())
 		{
 			NODELET_WARN("Synchronized and asynchronized user data topics cannot be used at the same time. Async user data dropped!");
@@ -1560,6 +1633,7 @@ void CoreWrapper::commonMultiCameraCallbackImpl(
 	}
 	else
 	{
+		boost::mutex::scoped_lock userDataLock(userDataMutex_);
 		userData = userData_;
 		userData_ = cv::Mat();
 	}
@@ -1606,14 +1680,22 @@ void CoreWrapper::commonMultiCameraCallbackImpl(
 		data.setFeatures(keypoints, points, descriptors);
 	}
 
-	process(lastPoseStamp_,
-			data,
-			lastPose_,
-			lastPoseVelocity_,
-			odomFrameId,
-			covariance_,
-			odomInfo,
-			timerConversion.ticks());
+	// Hand the frame over to processAsync(); the caller holds syncDataMutex_.
+	syncData_.data = data;
+	syncData_.valid = true;
+	syncData_.stamp = lastPoseStamp_;
+	syncData_.odom = lastPose_;
+	syncData_.odomVelocity = lastPoseVelocity_;
+	syncData_.odomFrameId = odomFrameId;
+	syncData_.odomCovariance = covariance_;
+	syncData_.odomInfo = odomInfo;
+	syncData_.timeMsgConversion = timerConversion.ticks();
+
+	if(!lastPoseIntermediate_)
+	{
+		previousStamp_ = lastPoseStamp_;
+	}
+
 	covariance_ = cv::Mat();
 }
 
@@ -1626,7 +1708,11 @@ void CoreWrapper::commonLaserScanCallback(
 		const rtabmap_msgs::GlobalDescriptor & globalDescriptor)
 {
 	UTimer timerConversion;
-	std::string odomFrameId = odomFrameId_;
+	std::string odomFrameId;
+	{
+		boost::mutex::scoped_lock lock(mapToOdomMutex_);
+		odomFrameId = odomFrameId_;
+	}
 	if(odomMsg.get())
 	{
 		odomFrameId = odomMsg->header.frame_id;
@@ -1667,6 +1753,14 @@ void CoreWrapper::commonLaserScanCallback(
 	{
 		return;
 	}
+
+	// Drop the frame if a previous one is still pending or being processed.
+	boost::unique_lock<boost::mutex> lock(syncDataMutex_, boost::try_to_lock);
+	if(!lock.owns_lock() || syncData_.valid)
+	{
+		return;
+	}
+	boost::mutex::scoped_lock poseLock(lastPoseMutex_);
 
 	LaserScan scan;
 	if(!scan2dMsg.ranges.empty())
@@ -1709,6 +1803,7 @@ void CoreWrapper::commonLaserScanCallback(
 	if(userDataMsg.get())
 	{
 		userData = rtabmap_conversions::userDataFromROS(*userDataMsg);
+		boost::mutex::scoped_lock userDataLock(userDataMutex_);
 		if(!userData_.empty())
 		{
 			NODELET_WARN("Synchronized and asynchronized user data topics cannot be used at the same time. Async user data dropped!");
@@ -1717,6 +1812,7 @@ void CoreWrapper::commonLaserScanCallback(
 	}
 	else
 	{
+		boost::mutex::scoped_lock userDataLock(userDataMutex_);
 		userData = userData_;
 		userData_ = cv::Mat();
 	}
@@ -1741,16 +1837,30 @@ void CoreWrapper::commonLaserScanCallback(
 		data.addGlobalDescriptor(rtabmap_conversions::globalDescriptorFromROS(globalDescriptor));
 	}
 
-	process(lastPoseStamp_,
-			data,
-			lastPose_,
-			lastPoseVelocity_,
-			odomFrameId,
-			covariance_,
-			odomInfo,
-			timerConversion.ticks());
+	// Hand the frame over to processAsync().
+	syncData_.data = data;
+	syncData_.valid = true;
+	syncData_.stamp = lastPoseStamp_;
+	syncData_.odom = lastPose_;
+	syncData_.odomVelocity = lastPoseVelocity_;
+	syncData_.odomFrameId = odomFrameId;
+	syncData_.odomCovariance = covariance_;
+	syncData_.odomInfo = odomInfo;
+	syncData_.timeMsgConversion = timerConversion.ticks();
+
+	if(!lastPoseIntermediate_)
+	{
+		previousStamp_ = lastPoseStamp_;
+	}
 
 	covariance_ = cv::Mat();
+
+	// Re-arm outside the locks: ros::WallTimer::stop() blocks until a running
+	// timer callback has returned, and processAsync() takes syncDataMutex_.
+	poseLock.unlock();
+	lock.unlock();
+	syncTimer_.stop();
+	syncTimer_.start();
 }
 
 void CoreWrapper::commonOdomCallback(
@@ -1760,18 +1870,26 @@ void CoreWrapper::commonOdomCallback(
 {
 	UTimer timerConversion;
 	UASSERT(odomMsg.get());
-	std::string odomFrameId = odomFrameId_;
+	std::string odomFrameId = odomMsg->header.frame_id;
 
-	odomFrameId = odomMsg->header.frame_id;
 	if(!odomUpdate(odomMsg, odomMsg->header.stamp))
 	{
 		return;
 	}
 
+	// Drop the frame if a previous one is still pending or being processed.
+	boost::unique_lock<boost::mutex> lock(syncDataMutex_, boost::try_to_lock);
+	if(!lock.owns_lock() || syncData_.valid)
+	{
+		return;
+	}
+	boost::mutex::scoped_lock poseLock(lastPoseMutex_);
+
 	cv::Mat userData;
 	if(userDataMsg.get())
 	{
 		userData = rtabmap_conversions::userDataFromROS(*userDataMsg);
+		boost::mutex::scoped_lock userDataLock(userDataMutex_);
 		if(!userData_.empty())
 		{
 			NODELET_WARN("Synchronized and asynchronized user data topics cannot be used at the same time. Async user data dropped!");
@@ -1780,6 +1898,7 @@ void CoreWrapper::commonOdomCallback(
 	}
 	else
 	{
+		boost::mutex::scoped_lock userDataLock(userDataMutex_);
 		userData = userData_;
 		userData_ = cv::Mat();
 	}
@@ -1798,16 +1917,30 @@ void CoreWrapper::commonOdomCallback(
 		odomInfo = rtabmap_conversions::odomInfoFromROS(*odomInfoMsg);
 	}
 
-	process(lastPoseStamp_,
-			data,
-			lastPose_,
-			lastPoseVelocity_,
-			odomFrameId,
-			covariance_,
-			odomInfo,
-			timerConversion.ticks());
+	// Hand the frame over to processAsync().
+	syncData_.data = data;
+	syncData_.valid = true;
+	syncData_.stamp = lastPoseStamp_;
+	syncData_.odom = lastPose_;
+	syncData_.odomVelocity = lastPoseVelocity_;
+	syncData_.odomFrameId = odomFrameId;
+	syncData_.odomCovariance = covariance_;
+	syncData_.odomInfo = odomInfo;
+	syncData_.timeMsgConversion = timerConversion.ticks();
+
+	if(!lastPoseIntermediate_)
+	{
+		previousStamp_ = lastPoseStamp_;
+	}
 
 	covariance_ = cv::Mat();
+
+	// Re-arm outside the locks: ros::WallTimer::stop() blocks until a running
+	// timer callback has returned, and processAsync() takes syncDataMutex_.
+	poseLock.unlock();
+	lock.unlock();
+	syncTimer_.stop();
+	syncTimer_.start();
 }
 
 void CoreWrapper::commonSensorDataCallback(
@@ -1817,7 +1950,11 @@ void CoreWrapper::commonSensorDataCallback(
 {
 	UTimer timerConversion;
 	UASSERT(sensorDataMsg.get());
-	std::string odomFrameId = odomFrameId_;
+	std::string odomFrameId;
+	{
+		boost::mutex::scoped_lock lock(mapToOdomMutex_);
+		odomFrameId = odomFrameId_;
+	}
 	if(odomMsg.get())
 	{
 		odomFrameId = odomMsg->header.frame_id;
@@ -1831,6 +1968,14 @@ void CoreWrapper::commonSensorDataCallback(
 		return;
 	}
 
+	// Drop the frame if a previous one is still pending or being processed.
+	boost::unique_lock<boost::mutex> lock(syncDataMutex_, boost::try_to_lock);
+	if(!lock.owns_lock() || syncData_.valid)
+	{
+		return;
+	}
+	boost::mutex::scoped_lock poseLock(lastPoseMutex_);
+
 	SensorData data = rtabmap_conversions::sensorDataFromROS(*sensorDataMsg);
 	data.setId(lastPoseIntermediate_?-1:0);
 
@@ -1840,16 +1985,58 @@ void CoreWrapper::commonSensorDataCallback(
 		odomInfo = rtabmap_conversions::odomInfoFromROS(*odomInfoMsg);
 	}
 
-	process(lastPoseStamp_,
-			data,
-			lastPose_,
-			lastPoseVelocity_,
-			odomFrameId,
-			covariance_,
-			odomInfo,
-			timerConversion.ticks());
+	// Hand the frame over to processAsync().
+	syncData_.data = data;
+	syncData_.valid = true;
+	syncData_.stamp = lastPoseStamp_;
+	syncData_.odom = lastPose_;
+	syncData_.odomVelocity = lastPoseVelocity_;
+	syncData_.odomFrameId = odomFrameId;
+	syncData_.odomCovariance = covariance_;
+	syncData_.odomInfo = odomInfo;
+	syncData_.timeMsgConversion = timerConversion.ticks();
+
+	if(!lastPoseIntermediate_)
+	{
+		previousStamp_ = lastPoseStamp_;
+	}
 
 	covariance_ = cv::Mat();
+
+	// Re-arm outside the locks: ros::WallTimer::stop() blocks until a running
+	// timer callback has returned, and processAsync() takes syncDataMutex_.
+	poseLock.unlock();
+	lock.unlock();
+	syncTimer_.stop();
+	syncTimer_.start();
+}
+
+void CoreWrapper::processAsync(const ros::WallTimerEvent & event)
+{
+	// Runs on the nodelet's single-threaded callback queue, so it cannot overlap
+	// with any service. syncDataMutex_ is held for the whole of process(), which
+	// is what makes the input callbacks drop frames instead of queuing them.
+	boost::mutex::scoped_lock lock(syncDataMutex_);
+
+	if(triggerNewMapBeforeNextUpdate_)
+	{
+		rtabmap_.triggerNewMap();
+		triggerNewMapBeforeNextUpdate_ = false;
+	}
+
+	if(syncData_.valid)
+	{
+		process(syncData_.stamp,
+				syncData_.data,
+				syncData_.odom,
+				syncData_.odomVelocity,
+				syncData_.odomFrameId,
+				syncData_.odomCovariance,
+				syncData_.odomInfo,
+				syncData_.timeMsgConversion);
+		syncData_.valid = false;
+		syncData_.data = SensorData();
+	}
 }
 
 void CoreWrapper::process(
@@ -1868,7 +2055,9 @@ void CoreWrapper::process(
 		// Add intermediate nodes?
 		for(std::list<std::pair<nav_msgs::Odometry, rtabmap_msgs::OdomInfo> >::iterator iter=interOdoms_.begin(); iter!=interOdoms_.end();)
 		{
-			if(iter->first.header.stamp < lastPoseStamp_)
+			// Use the stamp of the frame being processed, not lastPoseStamp_ which
+			// is owned by the input thread and may already have moved on.
+			if(iter->first.header.stamp < stamp)
 			{
 				Transform interOdom;
 				if(!rtabmap_.getLocalOptimizedPoses().empty())
@@ -2411,6 +2600,7 @@ void CoreWrapper::userDataAsyncCallback(const rtabmap_msgs::UserDataConstPtr & d
 {
 	if(!paused_)
 	{
+		boost::mutex::scoped_lock userDataLock(userDataMutex_);
 		static bool warningShow = false;
 		if(!userData_.empty() && !warningShow)
 		{
@@ -2896,6 +3086,8 @@ bool CoreWrapper::resetRtabmapCallback(std_srvs::Empty::Request&, std_srvs::Empt
 {
 	NODELET_INFO("rtabmap: Reset");
 	rtabmap_.resetMemory();
+	boost::mutex::scoped_lock poseLock(lastPoseMutex_);
+	boost::mutex::scoped_lock userDataLock(userDataMutex_);
 	covariance_ = cv::Mat();
 	lastPose_.setIdentity();
 	lastPoseVelocity_.clear();
@@ -2993,6 +3185,8 @@ bool CoreWrapper::loadDatabaseCallback(rtabmap_msgs::LoadDatabase::Request& req,
 	rtabmap_.close(saveDatabase);
 	NODELET_INFO("LoadDatabase: Saving current map (%s, %ld MB)... done!", databasePath_.c_str(), UFile::length(databasePath_)/(1024*1024));
 
+	boost::mutex::scoped_lock poseLock(lastPoseMutex_);
+	boost::mutex::scoped_lock userDataLock(userDataMutex_);
 	covariance_ = cv::Mat();
 	lastPose_.setIdentity();
 	lastPoseVelocity_.clear();
@@ -3145,6 +3339,8 @@ bool CoreWrapper::backupDatabaseCallback(std_srvs::Empty::Request&, std_srvs::Em
 	rtabmap_.close(saveDatabase);
 	NODELET_INFO("Backup: Saving memory... done!");
 
+	boost::mutex::scoped_lock poseLock(lastPoseMutex_);
+	boost::mutex::scoped_lock userDataLock(userDataMutex_);
 	covariance_ = cv::Mat();
 	lastPose_.setIdentity();
 	lastPoseVelocity_.clear();


### PR DESCRIPTION
Multithreaded rtabmap node (ROS1 port of #1214)

Message conversion and rtabmap_.process() ran inline in the synchronizer callback. When a processing cycle takes longer than the input period, frames accumulate in the transport queues, so the node keeps working on increasingly stale data and the reported delay grows until it saturates instead of staying bounded by the processing time.

Port the approach already used on the ros2 branch: the synchronized input topics get their own single-threaded callback queue, and process() runs from a one-shot WallTimer on the nodelet's ST callback queue. A frame arriving while a previous one is still pending or being processed is dropped on the spot rather than queued.

The nodelet ST callback queue is serviced by a single thread at a time (nodelet registers it with addQueue(st_queue, false)), so keeping the services, the async sensor topics and processAsync() on it makes them all mutually exclusive, which is what the ros2 branch gets from a MutuallyExclusive callback group.

Shared state between the two threads:
- syncDataMutex_ guards the single syncData_ slot and is held by processAsync() for the whole of process(), so a failing try_lock in the input callbacks is the "still busy" signal.
- lastPoseMutex_ guards lastPose*_, covariance_ and previousStamp_.
- userDataMutex_ guards userData_, which the async topic also writes.
- triggerNewMapBeforeNextUpdate_ defers rtabmap_.triggerNewMap() out of odomUpdate()/odomTFUpdate() so rtabmap_ is only touched from the processing thread.
- odomFrameId_ is read under mapToOdomMutex_, which process() already holds when writing it.

previousStamp_ is now advanced by the input callback once a frame is actually accepted, instead of in odomUpdate()/odomTFUpdate(), so a frame dropped because the previous one is still being processed does not shift the Rtabmap/DetectionRate window.

process() uses its stamp parameter instead of lastPoseStamp_ when trimming interOdoms_, since that member is owned by the input thread and may already have moved on.

# what's left

## ROS2 branch bug found
`landmarkCallbackGroup_` on ROS2 branch is not used, there is a bug where landmark callback is added to imu callback group instead of landmark callback group. Would need to open a PR for that.

```cpp
landmarkSubOptions.callback_group = imuCallbackGroup_;   // <-- imuCallbackGroup_, not landmarkCallbackGroup_
imuSubOptions.callback_group = imuCallbackGroup_;
```

## Move the async sensor topics off the processing queue

Currently every async sensor topic is still subscribed on the nodelet ST queue ([`CoreWrapper.cpp:884-895`](https://github.com/introlab/rtabmap_ros/blob/38b45dca161cea224702e5afcb9d9475911b2b1d/rtabmap_slam/src/CoreWrapper.cpp#L884-L895)), so they are blocked for the whole duration of `process()`.

**This is not a regression** — they were blocked exactly the same way before the change, because everything used to run on the ST queue.

**Why it's worth doing:** `imuSub_` has a queue depth of 100 at 100+ Hz, so a 1.3 s stall already overflows it and silently drops IMU samples today.

### What to move

| subscriber | line | callback | buffer it writes |
|---|---|---|---|
| `userDataAsyncSub_` | 884 | `userDataAsyncCallback` (2599) | `userData_` — **already guarded** by `userDataMutex_`  |
| `globalPoseAsyncSub_` | 885 | `globalPoseAsyncCallback` (2618) | `globalPose_` |
| `gpsFixAsyncSub_` | 886 | `gpsFixAsyncCallback` (2626) | `gps_` |
| `envSensorSub_` | 887 | `envSensorCallback` (2649) | `envSensors_` |
| `tagDetectionsSub_` | 889 | `tagDetectionsAsyncCallback` (2660) | `tags_` |
| `fiducialTransfromsSub_` | 892 | `fiducialDetectionsAsyncCallback` (2710) | `tags_` |
| `imuSub_` | 894 | `imuAsyncCallback` (2730) | `imus_` |

Move them from `nh` to `dataNh_` (or a third dedicated queue + spinner if you don't want them competing with image conversion for the single data thread).

### What that forces you to guard

`process()` reads **and clears** every one of those buffers — `globalPose_` at 2169-2205, `gps_` at 2211, `tags_` at 2215-2223, `envSensors_` at 2230, plus `imus_`. Today that is safe only because `process()` and these callbacks share the ST queue. The moment they move, each buffer needs a mutex, mirroring [`CoreWrapper.h:440-486`](https://github.com/introlab/rtabmap_ros/blob/16f6f05d70b299b2856b777c1a3db4ca0256fa6d/rtabmap_slam/include/rtabmap_slam/CoreWrapper.h#L440-L486) on the ros2 branch:

- `globalPoseMutex_`, `gpsMutex_`, `envSensorMutex_`, `landmarksMutex_` (covers `tags_`, written by both the apriltag and fiducial callbacks), `imuMutex_`
- `userDataMutex_` already exists

**Lock ordering:** the existing order is `syncDataMutex_` → `lastPoseMutex_` → `userDataMutex_`. Any new buffer mutex must be acquired *after* those, or in a scope that holds none of them, or you reintroduce an inversion. The three service handlers (`resetRtabmapCallback`, `loadDatabaseCallback`, `backupDatabaseCallback`) clear all these buffers while already holding `lastPoseMutex_` + `userDataMutex_`, so they are the place where the ordering will actually bite.

The three service resets also need the new mutexes added alongside the two they already take.

## Smaller deferred items

###  `publishLoop()` reads `odomFrameId_` outside the lock

[`CoreWrapper.cpp:993`](https://github.com/introlab/rtabmap_ros/blob/38b45dca161cea224702e5afcb9d9475911b2b1d/rtabmap_slam/src/CoreWrapper.cpp#L993):

```cpp
if(!odomFrameId_.empty())     // <-- unguarded read
{
    mapToOdomMutex_.lock();   // <-- lock starts here
    ...
    msg.child_frame_id = odomFrameId_;
```

`process()` writes `odomFrameId_` under `mapToOdomMutex_`, so this is a `std::string` read racing with an assignment. **Pre-existing** — the tf thread has always been separate from the ST queue — and untouched by phase 1, which is why I left it out to keep the diff focused. Two-line fix: move the `.empty()` check inside the lock.

### Reads left unguarded deliberately (same as ros2)

- `rtabmap_.getMemory() && uStrNumCmp(rtabmap_.getMemory()->getDatabaseVersion(), "0.11.10") < 0` in `commonLaserScanCallback` — read from the data thread while `process()` mutates `rtabmap_`. The database version is effectively immutable after init. The ros2 branch has the identical read inside its guarded block, so this port is consistent with upstream. Flagging it rather than fixing it.
- `paused_` — plain `bool`, written by the pause/resume services, read by the data thread. Same on ros2.

###  `defaultCallback` left on the ST queue

[`CoreWrapper.cpp:1009`](https://github.com/introlab/rtabmap_ros/blob/38b45dca161cea224702e5afcb9d9475911b2b1d/rtabmap_slam/src/CoreWrapper.cpp#L1009), the image-only fallback, still calls `rtabmap_.process()` synchronously. It is only subscribed when `!isDataSubscribed()`, i.e. when there are no data-queue callbacks at all, so there is no race. Intentionally unchanged.