### PR TITLE
Keep odometry-only arguments out of the RTAB-Map node

### DIFF
--- a/rtabmap_launch/CMakeLists.txt
+++ b/rtabmap_launch/CMakeLists.txt
@@ -7,4 +7,12 @@ install(DIRECTORY launch
    DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_rtabmap_launch_args
+    test/test_rtabmap_launch_args.py
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/launch
+  )
+endif()
+
 ament_package()

--- a/rtabmap_launch/launch/rtabmap.launch.py
+++ b/rtabmap_launch/launch/rtabmap.launch.py
@@ -4,6 +4,8 @@
 #
 
 import os
+import pathlib
+import sys
 
 from launch import LaunchDescription, Substitution, LaunchContext
 from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable, LogInfo, OpaqueFunction
@@ -13,6 +15,12 @@ from launch_ros.actions import Node
 from launch_ros.actions import SetParameter
 from typing import Text
 from ament_index_python.packages import get_package_share_directory
+
+THIS_DIR = pathlib.Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+from rtabmap_launch_args import filter_rtabmap_arguments
 
 #Based on https://answers.ros.org/question/363763/ros2-how-best-to-conditionally-include-a-prefix-in-a-launchpy-file/
 class ConditionalText(Substitution):
@@ -42,6 +50,9 @@ class ConditionalBool(Substitution):
 def launch_setup(context, *args, **kwargs):      
 
     rtabmap_viz_odometry_node_name = "rgbd_odometry"
+    filtered_rtabmap_args, removed_odom_args = filter_rtabmap_arguments(
+        LaunchConfiguration('rtabmap_args').perform(context)
+    )
     use_icp_odometry = LaunchConfiguration('icp_odometry').perform(context)
     use_icp_odometry = use_icp_odometry == 'true' or use_icp_odometry == 'True'
     use_stereo_odometry = LaunchConfiguration('stereo').perform(context)
@@ -51,10 +62,28 @@ def launch_setup(context, *args, **kwargs):
     elif use_stereo_odometry:
         rtabmap_viz_odometry_node_name = "stereo_odometry"
 
-    return [
+    rtabmap_node_arguments = list(filtered_rtabmap_args)
+    rtabmap_node_arguments.extend([
+        "--ros-args",
+        "--log-level",
+        [LaunchConfiguration('namespace'), '.rtabmap:=', LaunchConfiguration('log_level')],
+        "--log-level",
+        ['rtabmap:=', LaunchConfiguration('log_level')]
+    ])
+
+    launch_actions = []
+    if removed_odom_args:
+        launch_actions.append(
+            LogInfo(
+                msg='Ignoring odometry-only arguments for rtabmap node: ' +
+                ' '.join(removed_odom_args)
+            )
+        )
+
+    launch_actions.extend([
         DeclareLaunchArgument('depth', default_value=ConditionalText('false', 'true', IfCondition(PythonExpression(["'", LaunchConfiguration('stereo'), "' == 'true'"]))._predicate_func(context)), description=''),
         DeclareLaunchArgument('subscribe_rgb', default_value=LaunchConfiguration('depth'), description=''),
-        DeclareLaunchArgument('args',  default_value=LaunchConfiguration('rtabmap_args'), description='Can be used to pass RTAB-Map\'s parameters or other flags like --udebug and --delete_db_on_start/-d'),
+        DeclareLaunchArgument('args',  default_value=LaunchConfiguration('rtabmap_args'), description='Can be used to pass RTAB-Map\'s parameters or other flags like --udebug and --delete_db_on_start/-d. Odometry-only parameters (for example --Odom/ResetCountdown) are ignored by the rtabmap node and should be set in odom_args.'),
         DeclareLaunchArgument('sync_queue_size',  default_value=LaunchConfiguration('queue_size'), description='Queue size of topic synchronizers.'),
         DeclareLaunchArgument('qos_image',       default_value=LaunchConfiguration('qos'), description='Specific QoS used for image input data: 0=system default, 1=Reliable, 2=Best Effort.'),
         DeclareLaunchArgument('qos_camera_info', default_value=LaunchConfiguration('qos'), description='Specific QoS used for camera info input data: 0=system default, 1=Reliable, 2=Best Effort.'),
@@ -346,7 +375,7 @@ def launch_setup(context, *args, **kwargs):
                 ("odom", LaunchConfiguration('odom_topic')),
                 ("imu", LaunchConfiguration('imu_topic')),
                 ("goal_out", LaunchConfiguration('output_goal_topic'))],
-            arguments=[LaunchConfiguration("args"), "--ros-args", "--log-level", [LaunchConfiguration('namespace'), '.rtabmap:=', LaunchConfiguration('log_level')], "--log-level", ['rtabmap:=', LaunchConfiguration('log_level')]],
+            arguments=rtabmap_node_arguments,
             prefix=LaunchConfiguration('launch_prefix'),
             namespace=LaunchConfiguration('namespace')),
 
@@ -417,7 +446,8 @@ def launch_setup(context, *args, **kwargs):
                 ('rgb/camera_info', LaunchConfiguration('camera_info_topic')),
                 ('rgbd_image', LaunchConfiguration('rgbd_topic_relay')),
                 ('cloud', 'voxel_cloud')]),
-        ]
+        ])
+    return launch_actions
 
 def generate_launch_description():
     

--- a/rtabmap_launch/launch/rtabmap_launch_args.py
+++ b/rtabmap_launch/launch/rtabmap_launch_args.py
@@ -1,0 +1,32 @@
+import shlex
+
+
+def split_launch_arguments(argument_string):
+    if not argument_string:
+        return []
+    return shlex.split(argument_string)
+
+
+def filter_rtabmap_arguments(argument_string):
+    kept = []
+    removed = []
+    tokens = split_launch_arguments(argument_string)
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.startswith("--Odom/"):
+            removed.append(token)
+            if "=" not in token and index + 1 < len(tokens):
+                next_token = tokens[index + 1]
+                if not next_token.startswith("--"):
+                    removed.append(next_token)
+                    index += 2
+                    continue
+            index += 1
+            continue
+
+        kept.append(token)
+        index += 1
+
+    return kept, removed

--- a/rtabmap_launch/package.xml
+++ b/rtabmap_launch/package.xml
@@ -20,6 +20,9 @@
   <exec_depend>rtabmap_slam</exec_depend>
   <exec_depend>rtabmap_util</exec_depend>
   <exec_depend>rtabmap_viz</exec_depend>
+
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/rtabmap_launch/test/test_rtabmap_launch_args.py
+++ b/rtabmap_launch/test/test_rtabmap_launch_args.py
@@ -1,0 +1,70 @@
+import ast
+import pathlib
+import sys
+import unittest
+
+
+LAUNCH_DIR = pathlib.Path(__file__).resolve().parents[1] / "launch"
+sys.path.insert(0, str(LAUNCH_DIR))
+
+from rtabmap_launch_args import filter_rtabmap_arguments  # noqa: E402
+
+
+class FilterRtabmapArgumentsTest(unittest.TestCase):
+    def test_keeps_non_odom_arguments(self):
+        kept, removed = filter_rtabmap_arguments(
+            '--Vis/CorType 0 --Mem/IncrementalMemory false'
+        )
+
+        self.assertEqual(
+            kept,
+            ['--Vis/CorType', '0', '--Mem/IncrementalMemory', 'false'],
+        )
+        self.assertEqual(removed, [])
+
+    def test_filters_odom_parameter_pairs(self):
+        kept, removed = filter_rtabmap_arguments(
+            '--Vis/CorType 0 --Odom/ResetCountdown 20 --delete_db_on_start'
+        )
+
+        self.assertEqual(kept, ['--Vis/CorType', '0', '--delete_db_on_start'])
+        self.assertEqual(removed, ['--Odom/ResetCountdown', '20'])
+
+    def test_filters_inline_assignment(self):
+        kept, removed = filter_rtabmap_arguments(
+            '--Odom/ResetCountdown=20 --Grid/RangeMax 4.0'
+        )
+
+        self.assertEqual(kept, ['--Grid/RangeMax', '4.0'])
+        self.assertEqual(removed, ['--Odom/ResetCountdown=20'])
+
+    def test_launch_setup_filters_rtabmap_args_source(self):
+        launch_file = LAUNCH_DIR / 'rtabmap.launch.py'
+        tree = ast.parse(launch_file.read_text(encoding='utf-8'))
+
+        filter_calls = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'filter_rtabmap_arguments'
+        ]
+        self.assertEqual(len(filter_calls), 1)
+
+        filter_arg = filter_calls[0].args[0]
+        self.assertIsInstance(filter_arg, ast.Call)
+        self.assertIsInstance(filter_arg.func, ast.Attribute)
+        self.assertEqual(filter_arg.func.attr, 'perform')
+        self.assertIsInstance(filter_arg.func.value, ast.Call)
+        self.assertIsInstance(filter_arg.func.value.func, ast.Name)
+        self.assertEqual(filter_arg.func.value.func.id, 'LaunchConfiguration')
+        self.assertEqual(filter_arg.func.value.args[0].value, 'rtabmap_args')
+
+    def test_odometry_nodes_still_use_args_alias(self):
+        launch_file = LAUNCH_DIR / 'rtabmap.launch.py'
+        source = launch_file.read_text(encoding='utf-8')
+
+        self.assertIn('arguments=[LaunchConfiguration("args"), LaunchConfiguration("odom_args")', source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- filter `--Odom/*` options out of the `rtabmap` node's argument list
- preserve the existing shared and odometry-specific argument path for odometry nodes
- add five focused parser/launch-contract tests wired into the package's ament test flow
- clarify the launch argument description

## Why

`rtabmap.launch.py` forwarded shared RTAB-Map CLI arguments to both odometry and SLAM nodes. Odometry-only parameters such as `--Odom/ResetCountdown 20` then reached the `rtabmap` node, which does not declare them and aborts with `ParameterNotDeclaredException`.

## Verification

- `python -m pytest rtabmap_launch/test/test_rtabmap_launch_args.py -q` (5 passed)
- syntax compilation of all touched Python files
- `git diff --check`

A full `ros2 launch` / `colcon` run was not available locally and remains CI-bound.

Fixes #1304